### PR TITLE
feat: Treat non-web context as secure protocol.

### DIFF
--- a/src/content/utils/isContentScriptEnabled.js
+++ b/src/content/utils/isContentScriptEnabled.js
@@ -5,6 +5,9 @@ import { getAllowHttpFromStorage } from '../../shared/utils/allowHttpStorage'
  * The content script is enabled if the page uses a secure protocol (HTTPS)
  * or if the "Allow non-secure websites" setting is enabled in storage.
  *
+ * Note: Content scripts cannot run on `chrome://`, `about:`, `file://`, etc. (per browser policy restrictions),
+ * so no special protocol checks needed—these pages never execute this function.
+ *
  * @returns {Promise<boolean>} A promise that resolves to true if the content script is enabled, false otherwise.
  */
 export const isContentScriptEnabled = async () => {

--- a/src/shared/hooks/useActiveTabSecureProtocol.js
+++ b/src/shared/hooks/useActiveTabSecureProtocol.js
@@ -3,11 +3,17 @@ import { useMemo } from 'react'
 import { useActiveTabUrl } from './useActiveTabUrl'
 
 /**
- * Hook that determines if the currently active browser tab is using a secure protocol (HTTPS).
+ * Hook that determines if the currently active browser tab is using a secure protocol.
  * It listens for URL changes in the active tab and parses the protocol.
  *
+ * Protocol security rules:
+ * - `https:` → Secure (true)
+ * - `http:` → Insecure (false)
+ * - All other protocols (`chrome:`, `about:`, `file:`, etc.) → Treated as secure (true),
+ *   since they represent non-web contexts (e.g., browser internals, local files).
+ *
  * @returns {Object} An object containing:
- * @returns {boolean} .isSecure - True if the protocol is HTTPS or if the URL is still loading.
+ * @returns {boolean} .isSecure - True if protocol is HTTPS or non-HTTP/S; false only for HTTP.
  * @returns {string|null} .currentUrl - The full URL of the active tab.
  */
 export const useActiveTabSecureProtocol = () => {
@@ -18,9 +24,13 @@ export const useActiveTabSecureProtocol = () => {
 
     try {
       const url = new URL(currentUrl)
-      const secure = url.protocol === 'https:'
+      const protocol = url.protocol
 
-      return secure
+      if (protocol === 'https:') return true
+      if (protocol === 'http:') return false
+
+      // All others (chrome:, about:, file:, etc.): treat as secure
+      return true
     } catch (e) {
       return false
     }

--- a/src/shared/hooks/useActiveTabSecureProtocol.test.js
+++ b/src/shared/hooks/useActiveTabSecureProtocol.test.js
@@ -51,4 +51,28 @@ describe('useActiveTabSecureProtocol', () => {
 
     expect(result.current.isSecure).toBe(false)
   })
+
+  it('should return isSecure true when URL protocol is chrome:', () => {
+    useActiveTabUrl.mockReturnValue({ url: 'chrome://example.com' })
+    const { result } = renderHook(() => useActiveTabSecureProtocol())
+
+    expect(result.current.isSecure).toBe(true)
+    expect(result.current.currentUrl).toBe('chrome://example.com')
+  })
+
+  it('should return isSecure true when URL protocol is about:', () => {
+    useActiveTabUrl.mockReturnValue({ url: 'about:example' })
+    const { result } = renderHook(() => useActiveTabSecureProtocol())
+
+    expect(result.current.isSecure).toBe(true)
+    expect(result.current.currentUrl).toBe('about:example')
+  })
+
+  it('should return isSecure true when URL protocol is file:', () => {
+    useActiveTabUrl.mockReturnValue({ url: 'file://example.com' })
+    const { result } = renderHook(() => useActiveTabSecureProtocol())
+
+    expect(result.current.isSecure).toBe(true)
+    expect(result.current.currentUrl).toBe('file://example.com')
+  })
 })


### PR DESCRIPTION
https://app.asana.com/1/45238840754660/project/1210096266030915/task/1212775315528914

# Changes

 Protocol security rules:
  - `https:` → Secure (true)
  - `http:` → Insecure (false)
  - All other protocols (`chrome:`, `about:`, `file:`, etc.) → Treated as secure (true),  since they represent non-web contexts (e.g., browser internals, local files).
  
 # Note 

Since `useActiveTabSecureProtocol` returns `false` only for HTTP, I considered renaming the hook and checking only the HTTP condition. But it felt more readable to treat the 3 different protocols explicitly.

