### PR TITLE
Fix Autofill popup now showing in input fields

### DIFF
--- a/src/contentPopups/main.jsx
+++ b/src/contentPopups/main.jsx
@@ -1,10 +1,10 @@
 import { createRoot } from 'react-dom/client'
 
-import { AppWithBlockingState } from '../shared/containers/AppWithBlockingState'
+import { App } from './app/App'
 import { AppWrapper } from '../shared/containers/AppWrapper'
 
 createRoot(document.getElementById('root')).render(
   <AppWrapper>
-    <AppWithBlockingState />
+    <App />
   </AppWrapper>
 )


### PR DESCRIPTION
### Requirements

Autofill icon is not displayed in the field. It is impossible to use Autofill and Passkey

### Changes

The problem was with useModal call inside the useBlockingState(). In content popup we actually do not need AppWithBlockingState, because it's small UI component and we can't show modals/redirect there. So I removed it.

### Screenshots/Recordings


https://github.com/user-attachments/assets/bf09259e-a632-4dba-8ccf-dc85847faabe




