### PR TITLE
Fixed Autofill is not displayed within field until a user clicks outside of it

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -524,6 +524,14 @@ function hideLogoOnOutsideClick(event) {
     return
   }
 
+  if (
+    logoIframeData.element &&
+    document.activeElement &&
+    logoIframeData.element.isSameNode(document.activeElement)
+  ) {
+    return
+  }
+
   removeIframe(logoIframeData)
 }
 


### PR DESCRIPTION
### Requirements

The "Autofill"/"PassKey" icon is displayed within a website's "username" field when clicking on it the first time

### Changes

Added check on active document element before hiding the logo to ensure the icon stays visible even if the user clicks a surrounding element.

### Screenshots/Recordings


https://github.com/user-attachments/assets/754feeb6-5717-4997-9ce2-993323faa95c


