### PR TITLE
fix: autofill matcher update

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -7,7 +7,7 @@ import { LOGO_PADDING, LOGO_SIZE } from './constants/styles'
 import { createIframe } from './utils/createIframe'
 import { findLoginForms } from './utils/findLoginForms'
 import { findSelectOptionValue } from './utils/findSelectOptionValue'
-import { getField } from './utils/getField'
+import { getField, PASSWORD_MATCHERS } from './utils/getField'
 import { isContentScriptEnabled } from './utils/isContentScriptEnabled'
 import { isIdentityField } from './utils/isIdentityField'
 import { isPasswordField } from './utils/isPasswordField'
@@ -237,8 +237,9 @@ function handleAutofillLogin({ username, password }) {
   if (!isAutoFillEnabled) {
     return
   }
+
   const { element: usernameField } = getField(['username', 'email'])
-  const { element: passwordField } = getField(['password'])
+  const { element: passwordField } = getField(PASSWORD_MATCHERS)
 
   if (usernameField) {
     usernameField.value = username
@@ -437,7 +438,7 @@ function detectSubmitClick(event) {
   if (/(next|sign in|login|submit)/.test(label)) {
     setTimeout(() => {
       const { element: userNameField } = getField(['username', 'email'])
-      const { element: passwordField } = getField(['password'])
+      const { element: passwordField } = getField(PASSWORD_MATCHERS)
 
       const username = userNameField?.value
       const password = passwordField?.value

--- a/src/content/utils/getField.js
+++ b/src/content/utils/getField.js
@@ -1,23 +1,35 @@
+export const PASSWORD_MATCHERS = [
+  'password',
+  'pass',
+  'pwd',
+  'psswd',
+  'pw',
+  'passwd'
+]
+
 /**
  * @param {string[]} keywords
  * @returns {{ element: HTMLInputElement | HTMLSelectElement | null, type: 'input' | 'select' | null }}
  */
 export const getField = (keywords) => {
-  const selector = keywords
-    .flatMap((kw) => [
-      `input[name*="${kw}"]`,
-      `input[id*="${kw}"]`,
-      `input[autocomplete*="${kw}"]`,
-      `input[placeholder*="${kw}"]`,
-      `select[name*="${kw}"]`,
-      `select[id*="${kw}"]`,
-      `select[autocomplete*="${kw}"]`,
-      `label:has(input[id*="${kw}"]) input`,
-      `label:has(select[id*="${kw}"]) select`
-    ])
-    .join(',')
+  const lowerKeywords = keywords.map((kw) => kw.toLowerCase())
+  const attrNames = ['name', 'id', 'autocomplete', 'placeholder']
 
-  let element = document.querySelector(selector)
+  const matches = (element) =>
+    attrNames.some((attr) => {
+      const value = element.getAttribute(attr)
+      return (
+        value && lowerKeywords.some((kw) => value.toLowerCase().includes(kw))
+      )
+    })
+
+  let element = null
+  for (const el of document.querySelectorAll('input, select')) {
+    if (matches(el)) {
+      element = el
+      break
+    }
+  }
 
   if (!element) {
     element = getFieldByLabelText(keywords)
@@ -28,7 +40,6 @@ export const getField = (keywords) => {
   }
 
   const tag = element.tagName.toLowerCase()
-
   return {
     element,
     type: tag === 'input' ? 'input' : tag === 'select' ? 'select' : null

--- a/src/content/utils/getField.test.js
+++ b/src/content/utils/getField.test.js
@@ -1,10 +1,28 @@
-import { getField } from './getField'
+import { getField, PASSWORD_MATCHERS } from './getField'
 
 describe('getField', () => {
   let input, select, label, inputInLabel, selectInLabel
 
   beforeEach(() => {
     document.body.innerHTML = ''
+  })
+
+  it('should match unconventional password field name', () => {
+    document.body.innerHTML =
+      '<input type="password" class="inputtext _55r1 _6luy _9npi" name="psswd" id="psswd" data-testid="royal-psswd">'
+    const input = document.getElementById('psswd')
+    const res = getField(PASSWORD_MATCHERS)
+    expect(res.element).toBe(input)
+    expect(res.type).toBe('input')
+  })
+
+  it('should match case insensitive placeholder', () => {
+    document.body.innerHTML =
+      '<input type="password" class="inputtext _55r1 _6luy _9npi" name="pass" id="pass" data-testid="royal-pass" placeholder="Password" aria-label="Password">'
+    const input = document.getElementById('pass')
+    const res = getField(['password'])
+    expect(res.element).toBe(input)
+    expect(res.type).toBe('input')
   })
 
   it('returns nulls if no matching element', () => {


### PR DESCRIPTION
## Issue

The Facebook login page's autofill feature did not populate the password field.

## Reason

Facebook's DOM password input has 'pass' as the `name` attribute value, but the code was matching only `password` specifically.

## Solution

1. Made the `placeholder` attribute matching case-insensitive.
2. Created a `PASSWORD_MATCHERS` constant variable.

## Note 

The strongest password match would be checking if the `type` attribute equals `password`. However, I decided to continue with the current approach. If we choose to also check the `type` attribute, we'd need extra condition and function, which would complicate the code. The current "keyword matcher" approach works for password fields as well and therefore the code is cleaner.

## Note 

I can guarantee with 100% certainty there are other sites where we'll have issues finding inputs. Why? As one example, for login inputs we're matching `[username, email]`. But sites could easily use `usr, user, account, mail, e-mail`, etc., in the DOM.

We'll also have issues with other fields like `country`, `postcode`, etc.

Additionally, we'll encounter problems with non-English sites (French, Spanish, German, etc.) where the `name` attribute or other attributes may not contain English keywords.

Also some forms are more advanced, like Google’s, where the “login” input accepts either an “email” OR “phone” number. Pearpass has no way to match this properly if a user has previously stored both phone and email—Pearpass cannot decide which value to choose.

We could implement better fuzzy search and hierarchy algorithms, but these are hard to build and prone to false positives.

I believe that with hardcoded match values, a slightly more advanced algorithm, and extensive testing, we could cover 80% of forms.

For the remaining 20%, we'd need a completely different approach.

Brainstorm idea: What if we used the QVAC technology that Tether is developing? Local AI could find far better matches in "black box" DOM forms than we could ever hardcode.

One of Tether's goals with this repository is demonstrating P2P Holepunch technology. And in other projects Tether is promoting QVAC. We could integrate QVAC into PearPass—it would add extra value for users, and improving autofill with QVAC could be one possible feature. Just an idea.

## Note

Some password managers support a “custom field” feature. If the manager can’t find a field, users can manually select and label it for future autofills. Doable, but requires good UI design, proper storage handling, retrieval logic, etc.