### PR TITLE
fix: [Chrome][Auto-logout] Activity in the desktop should keep the session alive in it

### DIFF
--- a/src/hooks/useInactivity.js
+++ b/src/hooks/useInactivity.js
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-import { BE_AUTO_LOCK_ENABLED } from 'pearpass-lib-constants'
-import { closeAllInstances, useUserData, useVaults } from 'pearpass-lib-vault'
+import { useUserData, useVaults } from 'pearpass-lib-vault'
 
 import { useAutoLockPreferences } from './useAutoLockPreferences'
 import { NAVIGATION_ROUTES } from '../shared/constants/navigation'
@@ -51,9 +50,7 @@ export function useInactivity() {
 
       setIsLoading(true)
       closeAllModals()
-      if (BE_AUTO_LOCK_ENABLED) {
-        await closeAllInstances()
-      }
+
       setIsLoading(false)
 
       navigate('welcome', {


### PR DESCRIPTION

### Requirements
<!-- List the requirements for this PR -->
- Activity in the desktop should keep the session alive in it even when a User is logged out of the Browser extension
### Changes
<!-- Summarize the changes introduced in this PR -->
- Prevent closing all instances on browser extension auto-lock
### Testing Notes
<!-- How did you test it? -->
- Tested locally
### Things reviewers should pay attention to
<!-- Highlight anything specific you want reviewers to focus on -->

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/137b33a8-6f74-4a90-b2e8-a0934852c981


### dependencies
<!-- List any dependent work items or PRs -->
