### PR TITLE
Fix: window resize Ubuntu wayland

### DIFF
--- a/src/action/app/hooks/useWindowResize.js
+++ b/src/action/app/hooks/useWindowResize.js
@@ -8,15 +8,80 @@ import {
 import { useRouter } from '../../../shared/context/RouterContext'
 
 /**
- * Hook that dynamically resizes the extension popup window based on the current page
- * and returns the current window size for component styling.
+ * Resizes a Chrome window to the target inner dimensions.
  *
- * @returns {{width: number, height: number}} The current window size
+ * Due to a compositor-level quirk/bug in Ubuntu Wayland, the reported
+ * `outerWidth` can exceed the visually rendered size after the first pass.
+ * A second update is required to compensate for the outer/inner dimension
+ * difference and achieve the correct visible size for the user.
+ *
+ * On iOS, Ubuntu X11, and Windows, a single update is sufficient.
+ *
+ * Uses chrome.windows.get(windowId) instead of window.outerWidth/innerWidth
+ * to avoid reading incorrect window context when multiple Chrome windows
+ * or extension popups are open simultaneously.
+ *
+ * @param {number} windowId - The ID of the Chrome window to resize.
+ * @param {number} targetInnerWidth - The desired inner width in pixels.
+ * @param {number} targetInnerHeight - The desired inner height in pixels.
+ * @param {number} attempt - Current attempt number (used internally for recursion).
+ * @param {number} maxAttempts - Maximum number of resize attempts.
  */
+const resizeWindow = (
+  windowId,
+  targetInnerWidth,
+  targetInnerHeight,
+  attempt = 0,
+  maxAttempts = 3
+) => {
+  if (attempt >= maxAttempts) return
+
+  const frameWidth = window.outerWidth - window.innerWidth
+  const frameHeight = window.outerHeight - window.innerHeight
+
+  // Inner width/height should never exceed target — clamp frame offsets to minimum 0
+  const safeFrameWidth = Math.max(0, frameWidth)
+  const safeFrameHeight = Math.max(0, frameHeight)
+
+  const adjustedWidth = targetInnerWidth + safeFrameWidth
+  const adjustedHeight = targetInnerHeight + safeFrameHeight
+
+  chrome.windows.update(
+    windowId,
+    { width: adjustedWidth, height: adjustedHeight },
+    () => {
+      if (chrome.runtime.lastError) return
+
+      // Wait 100ms after first update before checking if sizes are correct
+      // Theory: sometimes results come back too fast before the window
+      // has actually finished resizing
+      setTimeout(() => {
+        chrome.windows.get(windowId, () => {
+          if (chrome.runtime.lastError) return
+
+          const newFrameWidth = window.outerWidth - window.innerWidth
+          const newFrameHeight = window.outerHeight - window.innerHeight
+
+          // End condition: no frame offset remaining — window is correctly sized
+          if (newFrameWidth === 0 && newFrameHeight === 0) return
+
+          // Retry to compensate for remaining frame offset (certain edge cases require this)
+          resizeWindow(
+            windowId,
+            targetInnerWidth,
+            targetInnerHeight,
+            attempt + 1,
+            maxAttempts
+          )
+        })
+      }, 100)
+    }
+  )
+}
+
 export const useWindowResize = () => {
   const { currentPage, state } = useRouter()
 
-  // Determine the target size based on current page
   const targetSize = useMemo(() => {
     const isPasskeyFlow =
       PASSKEY_PAGES.includes(currentPage) || state?.inPasskeyFlow === true
@@ -24,18 +89,10 @@ export const useWindowResize = () => {
   }, [currentPage, state])
 
   useEffect(() => {
-    // Resize the current popup window
     if (chrome?.windows?.getCurrent) {
       chrome.windows.getCurrent((currentWindow) => {
-        if (
-          currentWindow &&
-          currentWindow.type === 'popup' &&
-          chrome?.windows?.update
-        ) {
-          chrome.windows.update(currentWindow.id, {
-            width: targetSize.width,
-            height: targetSize.height
-          })
+        if (currentWindow?.type === 'popup' && chrome?.windows?.update) {
+          resizeWindow(currentWindow.id, targetSize.width, targetSize.height)
         }
       })
     }


### PR DESCRIPTION
It required a lot of debugging to find the core issues. On a surface level you would think it is a styling issue, but in reality it is a more system-specific quirk/bug.

## Issue

Popup windows in Ubuntu were truncated.

## Reason

More precisely, the issue manifested only in Ubuntu Wayland. X11 was fine.

It seems specific to the Wayland compositor GUI system and certain edge cases. I would consider it a bug on a system level.

## Solution

The solution is to run resize 2 times. The first time you get the difference between outer width and inner width, and then you apply the new changes. 2 times is enough. BUT in certain cases for some reason we might need to run it 3 times. So the solution includes a third attempt.

ALSO we need to add a timeout. There are some edge cases where the window is not updated fast enough and we get stale values.

ALSO we have to make sure the window ID is correct. There was an edge case I was able to reproduce when opening multiple windows alongside the action window popup — sometimes it caused the truncated popup window to show up again.

## before and after video
[old approach.webm](https://github.com/user-attachments/assets/299330eb-aede-4c30-95ed-a16fa31c3d5a)

[new approach.webm](https://github.com/user-attachments/assets/05b63a1a-a0ab-4490-bd5e-146e95b53f70)

## note 

In the video it seems that popup windows are going behind the main window, but this is caused because I keep clicking the main window buttons which will get the focus and therefore the main window will come to front again.