### PR TITLE
Fixed passkey not finding item without normalized url

### DIFF
--- a/src/shared/utils/isSameOrSubdomain.js
+++ b/src/shared/utils/isSameOrSubdomain.js
@@ -1,12 +1,29 @@
+import { normalizeUrl } from './normalizeUrl'
+
 /**
  * Checks if two domains are the same or have a valid subdomain relationship.
  * @param {string} a - First domain (potential subdomain)
  * @param {string} b - Second domain (potential parent domain)
  * @returns {boolean} True if domains are the same or 'a' is a subdomain of 'b'
  */
+const getHostname = (value) => {
+  if (!value || typeof value !== 'string') return null
+
+  const normalizedValue = normalizeUrl(value, true)
+  if (!normalizedValue) return null
+
+  try {
+    return new URL(normalizedValue).hostname.toLowerCase()
+  } catch {
+    return null
+  }
+}
+
 export const isSameOrSubdomain = (a, b) => {
-  if (!a || !b) return false
-  const normalizedA = a.toLowerCase()
-  const normalizedB = b.toLowerCase()
+  const normalizedA = getHostname(a)
+  const normalizedB = getHostname(b)
+
+  if (!normalizedA || !normalizedB) return false
+
   return normalizedA === normalizedB || normalizedA.endsWith(`.${normalizedB}`)
 }

--- a/src/shared/utils/isSameOrSubdomain.test.js
+++ b/src/shared/utils/isSameOrSubdomain.test.js
@@ -10,6 +10,12 @@ describe('isSameOrSubdomain', () => {
     expect(isSameOrSubdomain('example.com', 'EXAMPLE.COM')).toBe(true)
   })
 
+  test('should return true when current website uses www and saved website does not', () => {
+    expect(
+      isSameOrSubdomain('https://www.example.com', 'https://example.com')
+    ).toBe(true)
+  })
+
   test('should return true for valid subdomain', () => {
     expect(isSameOrSubdomain('app.example.com', 'example.com')).toBe(true)
     expect(isSameOrSubdomain('api.app.example.com', 'example.com')).toBe(true)


### PR DESCRIPTION
### Requirements

Login item is displayed in the item list when there is no "www." in the "website" field of the "Item" login

### Changes

Added normalize function for url 

### Screenshots/Recordings


https://github.com/user-attachments/assets/016393c2-f419-4bc9-a9b5-25fbc0e6d9e0



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213575943365411