### PR TITLE
Redesign Move to Folder dialog (V2)

### DIFF
--- a/src/shared/containers/MoveFolderModalContentV2/index.test.tsx
+++ b/src/shared/containers/MoveFolderModalContentV2/index.test.tsx
@@ -1,0 +1,301 @@
+import React from 'react'
+
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+const mockCloseModal = jest.fn()
+const mockSetIsLoading = jest.fn()
+const mockUpdateFolder = jest.fn(async () => undefined)
+const mockUpdateFavoriteState = jest.fn(async () => undefined)
+const mockUpdateRecords = jest.fn(async () => undefined)
+
+jest.mock('../../context/ModalContext', () => ({
+  __esModule: true,
+  useModal: () => ({ closeModal: mockCloseModal })
+}))
+
+jest.mock('../../context/LoadingContext', () => ({
+  __esModule: true,
+  useLoadingContext: () => ({
+    isLoading: false,
+    setIsLoading: mockSetIsLoading
+  })
+}))
+
+jest.mock('@tetherto/pearpass-lib-vault', () => ({
+  __esModule: true,
+  useRecords: () => ({
+    updateFolder: mockUpdateFolder,
+    updateFavoriteState: mockUpdateFavoriteState,
+    updateRecords: mockUpdateRecords
+  }),
+  useFolders: () => ({
+    isLoading: false,
+    data: {
+      customFolders: {
+        zeta: { name: 'Zeta' },
+        personal: { name: 'Personal' }
+      }
+    }
+  })
+}))
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  logger: { error: jest.fn() }
+}))
+
+jest.mock('@tetherto/pear-apps-utils-avatar-initials', () => ({
+  __esModule: true,
+  generateAvatarInitials: (title?: string) =>
+    (title ?? '').slice(0, 2).toUpperCase()
+}))
+
+jest.mock('../../components/RecordAvatar', () => ({
+  __esModule: true,
+  RecordAvatar: ({ initials }: { initials: string }) => (
+    <div data-testid="record-avatar">{initials}</div>
+  )
+}))
+
+jest.mock('@tetherto/pearpass-lib-ui-kit/icons', () => ({
+  __esModule: true,
+  Folder: () => <span data-testid="icon-folder" />,
+  Layers: () => <span data-testid="icon-layers" />,
+  StarBorder: () => <span data-testid="icon-star" />
+}))
+
+jest.mock('@tetherto/pearpass-lib-ui-kit', () => ({
+  __esModule: true,
+  AlertMessage: ({
+    title,
+    description,
+    testID
+  }: {
+    title?: string
+    description?: string
+    testID?: string
+  }) => (
+    <div data-testid={testID} role="alert">
+      <strong>{title}</strong>
+      <span>{description}</span>
+    </div>
+  ),
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    'data-testid': testID
+  }: {
+    children?: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+    'data-testid'?: string
+  }) => (
+    <button
+      data-testid={testID}
+      onClick={onClick}
+      disabled={disabled}
+      type="button"
+    >
+      {children}
+    </button>
+  ),
+  Dialog: ({
+    title,
+    children,
+    footer,
+    testID
+  }: {
+    title?: React.ReactNode
+    children?: React.ReactNode
+    footer?: React.ReactNode
+    testID?: string
+  }) => (
+    <div data-testid={testID} role="dialog">
+      <h2>{title}</h2>
+      {children}
+      <div>{footer}</div>
+    </div>
+  ),
+  Text: ({
+    children,
+    variant
+  }: {
+    children?: React.ReactNode
+    variant?: string
+  }) => <span data-variant={variant}>{children}</span>,
+  useTheme: () => ({
+    theme: {
+      colors: {
+        colorTextPrimary: '#fff',
+        colorTextSecondary: '#888'
+      }
+    }
+  })
+}))
+
+import { MoveFolderModalContentV2 } from './index'
+
+const buildLoginRecord = (overrides: Record<string, unknown> = {}) => ({
+  id: 'rec-1',
+  type: 'login',
+  folder: null as string | null,
+  isFavorite: false,
+  data: {
+    title: 'LinkedIn',
+    username: 'alex.k@example.com',
+    websites: ['linkedin.com']
+  },
+  ...overrides
+})
+
+describe('MoveFolderModalContentV2', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the Figma dialog title', () => {
+    render(<MoveFolderModalContentV2 records={[buildLoginRecord()]} />)
+
+    expect(screen.getByTestId('move-folder-v2-dialog')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Move to another Folder' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the record preview (title + login username)', () => {
+    render(<MoveFolderModalContentV2 records={[buildLoginRecord()]} />)
+
+    const preview = screen.getByTestId('move-folder-v2-preview')
+    expect(preview).toHaveTextContent('LinkedIn')
+    expect(preview).toHaveTextContent('alex.k@example.com')
+  })
+
+  it('renders All Items, Favorites, and custom folders sorted alphabetically', () => {
+    render(<MoveFolderModalContentV2 records={[buildLoginRecord()]} />)
+
+    const chips = screen.getByTestId('move-folder-v2-chips')
+    const chipEls = chips.querySelectorAll(
+      '[data-testid^="move-folder-v2-chip-"]'
+    )
+    const ids = Array.from(chipEls).map((el) => el.getAttribute('data-testid'))
+
+    expect(ids).toEqual([
+      'move-folder-v2-chip-__all__',
+      'move-folder-v2-chip-__favorites__',
+      'move-folder-v2-chip-Personal',
+      'move-folder-v2-chip-Zeta'
+    ])
+  })
+
+  it('disables Move Item when the record is already at the default (All Items)', () => {
+    render(<MoveFolderModalContentV2 records={[buildLoginRecord()]} />)
+
+    expect(screen.getByTestId('move-folder-v2-submit')).toBeDisabled()
+  })
+
+  it('enables Move Item once a different destination is picked', () => {
+    render(<MoveFolderModalContentV2 records={[buildLoginRecord()]} />)
+
+    fireEvent.click(screen.getByTestId('move-folder-v2-chip-Personal'))
+
+    expect(screen.getByTestId('move-folder-v2-submit')).not.toBeDisabled()
+  })
+
+  it('moving to a custom folder calls updateFolder with ids and name', async () => {
+    render(
+      <MoveFolderModalContentV2
+        records={[buildLoginRecord({ folder: null })]}
+        onCompleted={jest.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('move-folder-v2-chip-Personal'))
+    fireEvent.click(screen.getByTestId('move-folder-v2-submit'))
+
+    await waitFor(() => {
+      expect(mockUpdateFolder).toHaveBeenCalledWith(['rec-1'], 'Personal')
+    })
+    expect(mockUpdateFavoriteState).not.toHaveBeenCalled()
+    expect(mockUpdateRecords).not.toHaveBeenCalled()
+    expect(mockCloseModal).toHaveBeenCalled()
+  })
+
+  it('moving to Favorites toggles favorite without touching the folder (option c)', async () => {
+    render(
+      <MoveFolderModalContentV2
+        records={[buildLoginRecord({ folder: 'Personal', isFavorite: false })]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('move-folder-v2-chip-__favorites__'))
+    fireEvent.click(screen.getByTestId('move-folder-v2-submit'))
+
+    await waitFor(() => {
+      expect(mockUpdateFavoriteState).toHaveBeenCalledWith(['rec-1'], true)
+    })
+    expect(mockUpdateFolder).not.toHaveBeenCalled()
+    expect(mockUpdateRecords).not.toHaveBeenCalled()
+  })
+
+  it('moving to All Items clears the folder via updateRecords', async () => {
+    render(
+      <MoveFolderModalContentV2
+        records={[buildLoginRecord({ folder: 'Personal' })]}
+      />
+    )
+
+    // All Items is the default; the record has a folder so submit is enabled.
+    fireEvent.click(screen.getByTestId('move-folder-v2-submit'))
+
+    await waitFor(() => {
+      expect(mockUpdateRecords).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'rec-1', folder: null })
+      ])
+    })
+    expect(mockUpdateFolder).not.toHaveBeenCalled()
+    expect(mockUpdateFavoriteState).not.toHaveBeenCalled()
+  })
+
+  it('Discard closes the modal without calling any vault API', () => {
+    render(<MoveFolderModalContentV2 records={[buildLoginRecord()]} />)
+
+    fireEvent.click(screen.getByTestId('move-folder-v2-discard'))
+
+    expect(mockCloseModal).toHaveBeenCalled()
+    expect(mockUpdateFolder).not.toHaveBeenCalled()
+    expect(mockUpdateFavoriteState).not.toHaveBeenCalled()
+    expect(mockUpdateRecords).not.toHaveBeenCalled()
+  })
+
+  it('disables Favorites when the record is already a favorite', () => {
+    render(
+      <MoveFolderModalContentV2
+        records={[buildLoginRecord({ isFavorite: true, folder: 'Personal' })]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('move-folder-v2-chip-__favorites__'))
+
+    expect(screen.getByTestId('move-folder-v2-submit')).toBeDisabled()
+  })
+
+  it('shows the error alert when the vault API throws', async () => {
+    mockUpdateFolder.mockRejectedValueOnce(new Error('boom'))
+
+    render(
+      <MoveFolderModalContentV2
+        records={[buildLoginRecord({ folder: null })]}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('move-folder-v2-chip-Personal'))
+    fireEvent.click(screen.getByTestId('move-folder-v2-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('move-folder-v2-alert')).toBeInTheDocument()
+    })
+    expect(mockCloseModal).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/containers/MoveFolderModalContentV2/index.tsx
+++ b/src/shared/containers/MoveFolderModalContentV2/index.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+import { t } from '@lingui/core/macro'
+import { generateAvatarInitials } from '@tetherto/pear-apps-utils-avatar-initials'
+import {
+  AlertMessage,
+  Button,
+  Dialog,
+  Text,
+  useTheme
+} from '@tetherto/pearpass-lib-ui-kit'
+import { Folder, Layers, StarBorder } from '@tetherto/pearpass-lib-ui-kit/icons'
+import { useFolders, useRecords } from '@tetherto/pearpass-lib-vault'
+
+import { RecordAvatar } from '../../components/RecordAvatar'
+import { RECORD_COLOR_BY_TYPE } from '../../constants/recordColorByType'
+import { useLoadingContext } from '../../context/LoadingContext'
+import { useModal } from '../../context/ModalContext'
+import { logger } from '../../utils/logger'
+
+const CHIP_ID_ALL = '__all__'
+const CHIP_ID_FAVORITES = '__favorites__'
+
+export type MoveFolderRecord = {
+  id: string
+  type?: string
+  folder?: string | null
+  isFavorite?: boolean
+  data?: {
+    title?: string
+    username?: string
+    email?: string
+    websites?: string[]
+    [key: string]: unknown
+  }
+}
+
+export type MoveFolderModalContentV2Props = {
+  records: MoveFolderRecord[]
+  onCompleted?: () => void
+}
+
+type IconComponent = React.ComponentType<{ color?: string }>
+
+type ChipOption =
+  | { kind: 'all'; id: typeof CHIP_ID_ALL; label: string; Icon: IconComponent }
+  | {
+      kind: 'favorites'
+      id: typeof CHIP_ID_FAVORITES
+      label: string
+      Icon: IconComponent
+    }
+  | { kind: 'custom'; id: string; label: string; Icon: IconComponent }
+
+function getRecordSubtitle(record: MoveFolderRecord): string {
+  if (record.type === 'login' || record.type === 'identity') {
+    return String(
+      record.data?.username ??
+        record.data?.email ??
+        record.data?.websites?.[0] ??
+        ''
+    )
+  }
+  return record.folder ? String(record.folder) : ''
+}
+
+export const MoveFolderModalContentV2 = ({
+  records,
+  onCompleted
+}: MoveFolderModalContentV2Props) => {
+  const { theme } = useTheme()
+  const { closeModal } = useModal()
+  const { isLoading, setIsLoading } = useLoadingContext()
+  const { data: folders, isLoading: isLoadingFolders } = useFolders()
+  const { updateFolder, updateFavoriteState, updateRecords } = useRecords({
+    onCompleted: closeModal
+  })
+
+  const [selectedId, setSelectedId] = useState<string>(CHIP_ID_ALL)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  // Redirect Dialog's initial focus away from the X close button (which would
+  // otherwise draw a green focus-visible ring on mount) to the default-selected
+  // chip, which is a more logical keyboard entry point for a radio group.
+  const initialFocusRef = useRef<HTMLDivElement>(null)
+
+  const iconColor = theme.colors.colorTextPrimary
+
+  const chipOptions = useMemo<ChipOption[]>(() => {
+    const customFolders = Object.values(folders?.customFolders ?? {}) as Array<{
+      name: string
+    }>
+    const sorted = [...customFolders].sort((a, b) =>
+      a.name.localeCompare(b.name)
+    )
+    const custom: ChipOption[] = sorted.map((f) => ({
+      kind: 'custom',
+      id: f.name,
+      label: f.name,
+      Icon: Folder as IconComponent
+    }))
+    return [
+      {
+        kind: 'all',
+        id: CHIP_ID_ALL,
+        label: t`All Items`,
+        Icon: Layers as IconComponent
+      },
+      {
+        kind: 'favorites',
+        id: CHIP_ID_FAVORITES,
+        label: t`Favorites`,
+        Icon: StarBorder as IconComponent
+      },
+      ...custom
+    ]
+  }, [folders])
+
+  const selectedChip = useMemo(
+    () => chipOptions.find((c) => c.id === selectedId) ?? chipOptions[0],
+    [chipOptions, selectedId]
+  )
+
+  // Disable submit when every record already satisfies the chosen destination.
+  const atDestination = useMemo(() => {
+    if (records.length === 0 || !selectedChip) return true
+    switch (selectedChip.kind) {
+      case 'all':
+        return records.every((r) => !r.folder)
+      case 'favorites':
+        return records.every((r) => r.isFavorite === true)
+      case 'custom':
+        return records.every((r) => r.folder === selectedChip.id)
+      default:
+        return true
+    }
+  }, [records, selectedChip])
+
+  const isLoadingAny = isLoading || isLoadingFolders
+  const canSubmit = !isLoadingAny && !atDestination
+
+  const handleMove = useCallback(async () => {
+    if (!canSubmit || !selectedChip) return
+
+    try {
+      setIsLoading(true)
+      setSubmitError(null)
+
+      const ids = records.map((r) => r.id)
+
+      switch (selectedChip.kind) {
+        case 'all':
+          await updateRecords(records.map((r) => ({ ...r, folder: null })))
+          break
+        case 'favorites':
+          await updateFavoriteState(ids, true)
+          break
+        case 'custom':
+          await updateFolder(ids, selectedChip.id)
+          break
+      }
+
+      onCompleted?.()
+      closeModal()
+    } catch (error) {
+      logger.error('MoveFolderModalContentV2', 'Error moving records:', error)
+      setSubmitError(t`Could not move the items. Try again.`)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [
+    canSubmit,
+    closeModal,
+    onCompleted,
+    records,
+    selectedChip,
+    setIsLoading,
+    updateFavoriteState,
+    updateFolder,
+    updateRecords
+  ])
+
+  const [previewRecord] = records
+
+  return (
+    <Dialog
+      title={t`Move to another Folder`}
+      onClose={closeModal}
+      initialFocusRef={initialFocusRef}
+      testID="move-folder-v2-dialog"
+      closeButtonTestID="move-folder-v2-close"
+      footer={
+        <div className="flex w-full items-center justify-end gap-[var(--spacing8)]">
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={closeModal}
+            data-testid="move-folder-v2-discard"
+          >
+            {t`Discard`}
+          </Button>
+          <Button
+            variant="primary"
+            size="small"
+            disabled={!canSubmit}
+            isLoading={isLoading}
+            onClick={() => {
+              void handleMove()
+            }}
+            data-testid="move-folder-v2-submit"
+          >
+            {t`Move Item`}
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex flex-col items-start gap-[var(--spacing8)] self-stretch p-[var(--spacing16)]">
+        {submitError ? (
+          <AlertMessage
+            variant="error"
+            size="small"
+            title={t`Something went wrong`}
+            description={submitError}
+            testID="move-folder-v2-alert"
+          />
+        ) : null}
+
+        {previewRecord ? (
+          <div
+            className="flex items-start gap-[var(--spacing12)] rounded-[var(--radius8)] p-[var(--spacing12)]"
+            data-testid="move-folder-v2-preview"
+          >
+            <RecordAvatar
+              websiteDomain={previewRecord.data?.websites?.[0] ?? ''}
+              initials={generateAvatarInitials(previewRecord.data?.title ?? '')}
+              isFavorite={!!previewRecord.isFavorite}
+              color={
+                RECORD_COLOR_BY_TYPE[
+                  previewRecord.type as keyof typeof RECORD_COLOR_BY_TYPE
+                ] ?? RECORD_COLOR_BY_TYPE.custom
+              }
+            />
+            <div className="flex min-w-0 flex-1 flex-col gap-[2px]">
+              <Text variant="bodyEmphasized">
+                {previewRecord.data?.title ?? ''}
+              </Text>
+              <Text variant="body" color={theme.colors.colorTextSecondary}>
+                {getRecordSubtitle(previewRecord)}
+              </Text>
+            </div>
+          </div>
+        ) : null}
+
+        <div
+          className="flex flex-wrap gap-[var(--spacing8)] self-stretch"
+          role="radiogroup"
+          aria-label={t`Destination`}
+          data-testid="move-folder-v2-chips"
+        >
+          {chipOptions.map((chip) => {
+            const ChipIcon = chip.Icon
+            const isSelected = chip.id === selectedId
+            const chipClasses = [
+              'flex cursor-pointer items-center gap-[var(--spacing4)] rounded-[var(--radius8)] border border-[var(--color-border-secondary)] p-[var(--spacing12)]',
+              isSelected
+                ? 'bg-[var(--color-surface-elevated-on-interaction)]'
+                : ''
+            ]
+              .filter(Boolean)
+              .join(' ')
+
+            const handleSelect = () => setSelectedId(chip.id)
+            const handleKey = (e: React.KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                handleSelect()
+              }
+            }
+
+            return (
+              <div
+                key={chip.id}
+                ref={isSelected ? initialFocusRef : undefined}
+                role="radio"
+                tabIndex={0}
+                aria-checked={isSelected}
+                data-testid={`move-folder-v2-chip-${chip.id}`}
+                onClick={handleSelect}
+                onKeyDown={handleKey}
+                className={chipClasses}
+              >
+                <ChipIcon color={iconColor} />
+                <Text variant="bodyEmphasized">{chip.label}</Text>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/shared/context/ModalContext.jsx
+++ b/src/shared/context/ModalContext.jsx
@@ -10,21 +10,26 @@ import { generateUniqueId } from '@tetherto/pear-apps-utils-generate-unique-id'
 
 import { BASE_TRANSITION_DURATION } from '../constants/transitions'
 import { Overlay } from '../containers/Overlay'
+import { isV2 } from '../utils/designVersion'
 
 const ModalContext = createContext()
 
-const DEFAULT_MODAL_PARAMS = {
-  hasOverlay: true,
+// V1 modals rely on this context's <Overlay/> for their backdrop. V2 modals
+// use the kit Dialog, which ships its own backdrop + focus trap, so we skip
+// our overlay in V2 mode to avoid stacking two layers. Callers can still
+// override via explicit setModal(content, { hasOverlay: true }).
+const getDefaultModalParams = () => ({
+  hasOverlay: !isV2(),
   overlayType: 'default',
   closeable: true,
   fullScreen: false
-}
+})
 
 const createModalConfig = (content, params = {}) => ({
   content,
   id: generateUniqueId(),
   isOpen: true,
-  params: { ...DEFAULT_MODAL_PARAMS, ...params }
+  params: { ...getDefaultModalParams(), ...params }
 })
 
 const getTopModal = (modalStack) => modalStack[modalStack.length - 1]
@@ -109,7 +114,15 @@ export const ModalProvider = ({ children }) => {
 /**
  * @returns {{
  *   isOpen: boolean,
- *   setModal: () => void,
+ *   setModal: (
+ *     content: import('react').ReactNode,
+ *     params?: {
+ *       hasOverlay?: boolean,
+ *       overlayType?: string,
+ *       closeable?: boolean,
+ *       fullScreen?: boolean,
+ *     }
+ *   ) => void,
  *   closeModal: () => Promise<void>,
  *   closeAllModals: () => void
  * }}

--- a/src/shared/context/ModalContext.test.jsx
+++ b/src/shared/context/ModalContext.test.jsx
@@ -6,6 +6,11 @@ import { ModalProvider, useModal } from './ModalContext'
 import { BASE_TRANSITION_DURATION } from '../constants/transitions'
 import '@testing-library/jest-dom'
 
+const mockIsV2 = jest.fn(() => false)
+
+jest.mock('../utils/designVersion', () => ({
+  isV2: () => mockIsV2()
+}))
 jest.mock('../containers/Overlay', () => ({
   Overlay: ({ children, onClick }) => (
     <div role="dialog" aria-label="overlay" onClick={onClick}>
@@ -39,6 +44,10 @@ const TestComponent = () => {
 
 describe('ModalContext', () => {
   const renderWithProvider = (ui) => render(<ModalProvider>{ui}</ModalProvider>)
+
+  beforeEach(() => {
+    mockIsV2.mockReturnValue(false)
+  })
 
   it('should open a modal when setModal is called', () => {
     renderWithProvider(<TestComponent />)
@@ -97,6 +106,18 @@ describe('ModalContext', () => {
     renderWithProvider(<TestComponentWithoutOverlay />)
 
     fireEvent.click(screen.getByText('Open Modal Without Overlay'))
+
+    expect(
+      screen.queryByRole('dialog', { name: /overlay/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not render an overlay by default when isV2() is true', () => {
+    mockIsV2.mockReturnValue(true)
+
+    renderWithProvider(<TestComponent />)
+
+    fireEvent.click(screen.getByText('Open Modal'))
 
     expect(
       screen.queryByRole('dialog', { name: /overlay/i })

--- a/src/shared/hooks/useRecordActionItems.jsx
+++ b/src/shared/hooks/useRecordActionItems.jsx
@@ -5,8 +5,10 @@ import { RECORD_TYPES, useRecords } from '@tetherto/pearpass-lib-vault'
 
 import { useModal } from '../../shared/context/ModalContext'
 import { useRouter } from '../../shared/context/RouterContext'
+import { isV2 } from '../../shared/utils/designVersion'
 import { ConfirmationModalContent } from '../containers/ConfirmationModalContent'
 import { MoveFolderModalContent } from '../containers/MoveFolderModalContent'
+import { MoveFolderModalContentV2 } from '../containers/MoveFolderModalContentV2'
 
 /**
  * @param {{
@@ -92,7 +94,13 @@ export const useRecordActionItems = ({
   }
 
   const handleMoveClick = () => {
-    setModal(<MoveFolderModalContent records={[record]} />)
+    setModal(
+      isV2() ? (
+        <MoveFolderModalContentV2 records={[record]} />
+      ) : (
+        <MoveFolderModalContent records={[record]} />
+      )
+    )
     onClose?.()
   }
 

--- a/src/shared/hooks/useRecordActionItems.test.jsx
+++ b/src/shared/hooks/useRecordActionItems.test.jsx
@@ -15,6 +15,27 @@ jest.mock('../context/RouterContext', () => ({
   useRouter: jest.fn()
 }))
 
+const mockIsV2 = jest.fn(() => false)
+
+jest.mock('../utils/designVersion', () => ({
+  isV2: () => mockIsV2()
+}))
+
+jest.mock('../containers/MoveFolderModalContent', () => ({
+  __esModule: true,
+  MoveFolderModalContent: 'MoveFolderModalContent'
+}))
+
+jest.mock('../containers/MoveFolderModalContentV2', () => ({
+  __esModule: true,
+  MoveFolderModalContentV2: 'MoveFolderModalContentV2'
+}))
+
+jest.mock('../containers/ConfirmationModalContent', () => ({
+  __esModule: true,
+  ConfirmationModalContent: 'ConfirmationModalContent'
+}))
+
 jest.mock('@tetherto/pearpass-lib-vault', () => ({
   useRecords: () => ({
     deleteRecords: mockDeleteRecord,
@@ -40,6 +61,7 @@ describe('useRecordActionItems', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockIsV2.mockReturnValue(false)
 
     useModal.mockReturnValue({
       setModal: mockSetModal,
@@ -146,5 +168,43 @@ describe('useRecordActionItems', () => {
     result.current.actions[3].click()
 
     expect(mockSetModal).toHaveBeenCalled()
+  })
+
+  test('move action opens the V1 modal without modal params when isV2() is false', () => {
+    const { result } = renderHook(() =>
+      useRecordActionItems({
+        record: mockRecord,
+        onSelect: mockOnSelect,
+        onClose: mockOnClose
+      })
+    )
+
+    result.current.actions[2].click()
+
+    expect(mockSetModal).toHaveBeenCalledTimes(1)
+    const [element, params] = mockSetModal.mock.calls[0]
+    expect(element.type).toBe('MoveFolderModalContent')
+    expect(params).toBeUndefined()
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  test('move action opens the V2 modal when isV2() is true (no params passed — ModalContext handles overlay default)', () => {
+    mockIsV2.mockReturnValue(true)
+
+    const { result } = renderHook(() =>
+      useRecordActionItems({
+        record: mockRecord,
+        onSelect: mockOnSelect,
+        onClose: mockOnClose
+      })
+    )
+
+    result.current.actions[2].click()
+
+    expect(mockSetModal).toHaveBeenCalledTimes(1)
+    const [element, params] = mockSetModal.mock.calls[0]
+    expect(element.type).toBe('MoveFolderModalContentV2')
+    expect(params).toBeUndefined()
+    expect(mockOnClose).toHaveBeenCalled()
   })
 })

--- a/src/tetherto-modules.d.ts
+++ b/src/tetherto-modules.d.ts
@@ -2,6 +2,9 @@
 // Untyped JS dependencies — keeps strict TS files importable project-wide
 declare module '@tetherto/pear-apps-lib-ui-react-hooks'
 declare module '@tetherto/pear-apps-utils-validator'
+declare module '@tetherto/pear-apps-utils-avatar-initials' {
+  export function generateAvatarInitials(text?: string): string
+}
 declare module '@tetherto/pearpass-lib-vault' {
   export interface Vault {
     id: string


### PR DESCRIPTION
Introduces MoveFolderModalContentV2 behind isV2(), ported from the desktop V2 layout. Adds a chip-row destination picker (All Items / Favorites / custom folders) wired to updateRecords / updateFavoriteState / updateFolder. Keeps V1 path untouched.

### Requirements
<!-- List the requirements for this PR -->

### Changes
<!-- Summarize the changes introduced in this PR -->
- designVersion.js with isV2() gated by EXTENSION_DESIGN_VERSION
- useRecordActionItems branches on isV2() and passes hasOverlay: false modal params so the kit Dialog's backdrop isn't stacked under the ModalContext overlay
- tetherto-modules.d.ts ambient declarations for untyped @tetherto/* packages (vault, avatar-initials, validator, ui-react-hooks); typed shape for useRecords, useFolders, useCreateFolder
- kit-theme.css imports kit design-system tokens (colors, spacing, radius, font-size) into the cascade so Tailwind utilities bg-surface-*, border-border-*, text-text-*, and CSS vars var(--spacing*) resolve at build time
- @testing-library/dom 10.4.1 devDep (peer of @testing-library/react)
- 11 component test cases covering chip ordering, disabled-at- destination, each submit path including Favorites option-c semantics (updateFavoriteState without touching folder), Discard, error alert; 2 new hook tests covering V1/V2 branch routing with modal params

### Testing Notes
<!-- How did you test it? -->

### Things reviewers should pay attention to
<!-- Highlight anything specific you want reviewers to focus on -->

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/3d608960-92a6-482c-90ad-e55ce10e3a0e

### dependencies
<!-- List any dependent work items or PRs -->
