### PR TITLE
feat: App Version and Language pages

### DIFF
--- a/src/action/index.jsx
+++ b/src/action/index.jsx
@@ -14,12 +14,21 @@ import { LoadingProvider } from '../shared/context/LoadingContext'
 import { ModalProvider } from '../shared/context/ModalContext'
 import { RouterProvider } from '../shared/context/RouterContext'
 import { ToastProvider } from '../shared/context/ToastContext'
+import { getLocaleFromStorage } from '../shared/utils/localeStorage'
 import { logger } from '../shared/utils/logger'
 import '../index.css'
 import '../strict.css'
 
 i18n.load('en', messages)
 i18n.activate('en')
+
+getLocaleFromStorage()
+  .then((stored) => {
+    if (stored && stored !== i18n.locale) i18n.activate(stored)
+  })
+  .catch((error) => {
+    logger.error('Failed to load persisted locale:', error)
+  })
 
 createClient()
   .then(() => {

--- a/src/action/pages/SettingsV2/content/AppVersionContent/index.tsx
+++ b/src/action/pages/SettingsV2/content/AppVersionContent/index.tsx
@@ -66,7 +66,7 @@ export const AppVersionContent = () => {
 
       <div
         data-testid={TEST_IDS.versionRow}
-        className="border-border-primary flex w-full items-center justify-between rounded-[8px] border px-[12px] py-[15px]"
+        className="border-border-primary flex w-full items-center justify-between rounded-[8px] border px-[12px] py-[16px]"
       >
         <Text variant="labelEmphasized">{t`App version`}</Text>
         <Text

--- a/src/action/pages/SettingsV2/content/AppVersionContent/index.tsx
+++ b/src/action/pages/SettingsV2/content/AppVersionContent/index.tsx
@@ -1,11 +1,82 @@
 import { t } from '@lingui/core/macro'
-import { PageHeader } from '@tetherto/pearpass-lib-ui-kit'
+import { Trans } from '@lingui/react/macro'
+import {
+  PEARPASS_WEBSITE,
+  PRIVACY_POLICY,
+  TERMS_OF_USE
+} from '@tetherto/pearpass-lib-constants'
+import { Link, PageHeader, Text, useTheme } from '@tetherto/pearpass-lib-ui-kit'
 
-export const AppVersionContent = () => (
-  <PageHeader
-    as="h1"
-    testID="settings-app-version"
-    title={t`App version`}
-    subtitle={t`Here you can find all the info about your app.`}
-  />
-)
+import { version } from '../../../../../../public/manifest.json'
+
+const TEST_IDS = {
+  root: 'settings-app-version',
+  termsLink: 'settings-app-version-terms-link',
+  privacyLink: 'settings-app-version-privacy-link',
+  websiteLink: 'settings-app-version-website-link',
+  versionRow: 'settings-app-version-row',
+  versionValue: 'settings-app-version-value'
+} as const
+
+export const AppVersionContent = () => {
+  const { theme } = useTheme()
+  const { colors } = theme
+
+  return (
+    <div
+      data-testid={TEST_IDS.root}
+      className="flex w-full flex-col gap-[24px]"
+    >
+      <PageHeader
+        as="h1"
+        title={t`App version`}
+        subtitle={
+          <Text variant="body" color={colors.colorTextSecondary}>
+            <Trans>
+              Here you can find all the info about your app. Check here to see
+              the{' '}
+              <Link
+                href={TERMS_OF_USE}
+                isExternal
+                data-testid={TEST_IDS.termsLink}
+              >
+                Terms of Use
+              </Link>
+              ,{' '}
+              <Link
+                href={PRIVACY_POLICY}
+                isExternal
+                data-testid={TEST_IDS.privacyLink}
+              >
+                Privacy Statement
+              </Link>{' '}
+              and{' '}
+              <Link
+                href={PEARPASS_WEBSITE}
+                isExternal
+                data-testid={TEST_IDS.websiteLink}
+              >
+                visit our website
+              </Link>
+              .
+            </Trans>
+          </Text>
+        }
+      />
+
+      <div
+        data-testid={TEST_IDS.versionRow}
+        className="border-border-primary flex w-full items-center justify-between rounded-[8px] border px-[12px] py-[15px]"
+      >
+        <Text variant="labelEmphasized">{t`App version`}</Text>
+        <Text
+          variant="body"
+          color={colors.colorLinkText}
+          data-testid={TEST_IDS.versionValue}
+        >
+          {version}
+        </Text>
+      </div>
+    </div>
+  )
+}

--- a/src/action/pages/SettingsV2/content/LanguageContent/index.tsx
+++ b/src/action/pages/SettingsV2/content/LanguageContent/index.tsx
@@ -13,6 +13,7 @@ import {
 import { KeyboardArrowBottom } from '@tetherto/pearpass-lib-ui-kit/icons'
 
 import { useLanguageOptions } from '../../../../../hooks/useLanguageOptions'
+import { setLocaleInStorage } from '../../../../../shared/utils/localeStorage'
 
 const TEST_IDS = {
   root: 'settings-language',
@@ -42,6 +43,7 @@ export const LanguageContent = () => {
     (option: LanguageOption) => {
       setLanguage(option.value)
       i18n.activate(option.value)
+      void setLocaleInStorage(option.value)
       setIsDropdownOpen(false)
     },
     [i18n]

--- a/src/action/pages/SettingsV2/content/LanguageContent/index.tsx
+++ b/src/action/pages/SettingsV2/content/LanguageContent/index.tsx
@@ -1,11 +1,99 @@
-import { t } from '@lingui/core/macro'
-import { PageHeader } from '@tetherto/pearpass-lib-ui-kit'
+import { useCallback, useState } from 'react'
 
-export const LanguageContent = () => (
-  <PageHeader
-    as="h1"
-    testID="settings-language"
-    title={t`Language`}
-    subtitle={t`Choose the language used across PearPass.`}
-  />
-)
+import { t } from '@lingui/core/macro'
+import { useLingui } from '@lingui/react/macro'
+import {
+  Button,
+  Dropdown,
+  NavbarListItem,
+  PageHeader,
+  Text,
+  useTheme
+} from '@tetherto/pearpass-lib-ui-kit'
+import { KeyboardArrowBottom } from '@tetherto/pearpass-lib-ui-kit/icons'
+
+import { useLanguageOptions } from '../../../../../hooks/useLanguageOptions'
+
+const TEST_IDS = {
+  root: 'settings-language',
+  card: 'settings-language-card',
+  trigger: 'settings-language-trigger',
+  option: 'settings-language-option'
+} as const
+
+type LanguageOption = { label: string; value: string }
+
+export const LanguageContent = () => {
+  const { i18n } = useLingui()
+  const { theme } = useTheme()
+  const { colors } = theme
+  const { languageOptions } = useLanguageOptions() as {
+    languageOptions: LanguageOption[]
+  }
+
+  const [language, setLanguage] = useState(i18n.locale)
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+
+  const selectedOption =
+    languageOptions.find((option) => option.value === language) ??
+    languageOptions[0]
+
+  const handleSelect = useCallback(
+    (option: LanguageOption) => {
+      setLanguage(option.value)
+      i18n.activate(option.value)
+      setIsDropdownOpen(false)
+    },
+    [i18n]
+  )
+
+  return (
+    <div
+      data-testid={TEST_IDS.root}
+      className="flex w-full flex-col gap-[24px]"
+    >
+      <PageHeader
+        as="h1"
+        title={t`Language`}
+        subtitle={t`Choose the language of the app.`}
+      />
+
+      <div
+        data-testid={TEST_IDS.card}
+        className="bg-surface-primary border-border-primary flex items-center gap-[12px] rounded-[8px] border p-[12px]"
+      >
+        <div className="flex min-w-0 flex-1 flex-col gap-[4px]">
+          <Text variant="labelEmphasized">{t`App Language`}</Text>
+          <Text variant="caption" color={colors.colorTextSecondary}>
+            {t`Select the language used throughout PearPass.`}
+          </Text>
+        </div>
+
+        <Dropdown
+          open={isDropdownOpen}
+          onOpenChange={setIsDropdownOpen}
+          trigger={
+            <Button
+              variant="secondary"
+              size="small"
+              iconAfter={<KeyboardArrowBottom />}
+              data-testid={TEST_IDS.trigger}
+            >
+              {selectedOption?.label ?? t`Select`}
+            </Button>
+          }
+        >
+          {languageOptions.map((option) => (
+            <NavbarListItem
+              key={option.value}
+              testID={`${TEST_IDS.option}-${option.value}`}
+              label={option.label}
+              selected={option.value === language}
+              onClick={() => handleSelect(option)}
+            />
+          ))}
+        </Dropdown>
+      </div>
+    </div>
+  )
+}

--- a/src/shared/constants/storage.js
+++ b/src/shared/constants/storage.js
@@ -8,7 +8,8 @@ export const LOCAL_STORAGE_KEYS = {
 
 export const CHROME_STORAGE_KEYS = {
   AUTOFILL_ENABLED: 'autofill-enabled',
-  ALLOW_HTTP_ENABLED: 'allow-http-enabled'
+  ALLOW_HTTP_ENABLED: 'allow-http-enabled',
+  LOCALE: 'locale'
 }
 
 export const PASSKEY_VERIFICATION_OPTIONS = {

--- a/src/shared/utils/localeStorage.js
+++ b/src/shared/utils/localeStorage.js
@@ -1,0 +1,24 @@
+import { CHROME_STORAGE_KEYS } from '../constants/storage'
+
+/**
+ * Gets the persisted locale from Chrome storage.
+ * @returns {Promise<string | null>} Promise that resolves to the stored locale code, or null if unset/unavailable.
+ */
+export const getLocaleFromStorage = async () => {
+  if (!chrome?.storage?.local?.get) return null
+  const res = await chrome.storage.local.get(CHROME_STORAGE_KEYS.LOCALE)
+  const locale = res?.[CHROME_STORAGE_KEYS.LOCALE]
+  return typeof locale === 'string' && locale ? locale : null
+}
+
+/**
+ * Persists the active locale to Chrome storage.
+ * @param {string} locale - BCP47-style language code (e.g. "en", "it").
+ * @returns {Promise<void>}
+ */
+export const setLocaleInStorage = async (locale) => {
+  if (!chrome?.storage?.local?.set) return
+  await chrome.storage.local.set({
+    [CHROME_STORAGE_KEYS.LOCALE]: locale
+  })
+}


### PR DESCRIPTION
Rebuilt two settings screens — Language and App Version — to match the new design.

https://github.com/user-attachments/assets/977b80df-4bfa-4b81-872d-639daff31db0

<img width="651" height="492" alt="Screenshot 2026-04-27 at 16 04 44" src="https://github.com/user-attachments/assets/ac334142-3af0-4e45-b561-65ee8708d060" />
<img width="648" height="500" alt="Screenshot 2026-04-27 at 16 04 36" src="https://github.com/user-attachments/assets/cf21480f-300d-437c-9090-f635689bee1d" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214113487981828