### PR TITLE
Current vault exp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3847,7 +3847,7 @@
     "node_modules/@tetherto/pearpass-lib-ui-kit": {
       "name": "pearpass-lib-ui-react-native-components",
       "version": "0.0.40",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#217a6bdef25364f5964158d1e5f4b8488db337d7",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#636989931c65a63d4dd429911facbf38d60d1fc2",
       "license": "Apache-2.0",
       "dependencies": {
         "react-strict-dom": "^0.0.55"

--- a/src/action/pages/SettingsV2/content/YourVaultsContent/index.tsx
+++ b/src/action/pages/SettingsV2/content/YourVaultsContent/index.tsx
@@ -31,6 +31,7 @@ import { CreateOrEditVaultModalContentV2 } from '../../../../../shared/container
 import { PairedDevicesModalContent } from '../../../../../shared/containers/PairedDevicesModalContent'
 import { useModal } from '../../../../../shared/context/ModalContext'
 import { sortByName } from '../../../../../shared/utils/sortByName'
+import { useVaultSwitch } from '../../../../../shared/hooks/useVaultSwitch'
 
 const VAULT_ICON_BG = { backgroundColor: 'rgba(176, 217, 68, 0.18)' }
 
@@ -40,7 +41,7 @@ export const YourVaultsContent = () => {
     closeModal: () => Promise<void>
   }
   const { theme } = useTheme()
-
+  const { switchVault } = useVaultSwitch()
   const { data: vault } = useVault()
   const { data: allVaults } = useVaults()
 
@@ -114,7 +115,7 @@ export const YourVaultsContent = () => {
           as="h1"
           testID="settings-vault"
           title={t`Your Vaults`}
-          subtitle={t`Manage your vaults, control access permissions, and take protective measures if needed.`}
+          subtitle={t`Manage your vaults. Select the vault you want to apply changes to.`}
         />
       </div>
 
@@ -222,7 +223,9 @@ export const YourVaultsContent = () => {
               <ListItem
                 testID={`settings-other-vault-${v.name}-${index}`}
                 title={v.name}
+                onClick={() => switchVault(v)}
                 showDivider={index == otherVaults.length - 1}
+                withRoundedBorders={false}
                 icon={
                   <div
                     className="flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-[8px]"

--- a/src/action/pages/SettingsV2/content/YourVaultsContent/index.tsx
+++ b/src/action/pages/SettingsV2/content/YourVaultsContent/index.tsx
@@ -223,7 +223,7 @@ export const YourVaultsContent = () => {
               <ListItem
                 testID={`settings-other-vault-${v.name}-${index}`}
                 title={v.name}
-                onClick={() => switchVault(v)}
+                onClick={() => void switchVault(v)}
                 showDivider={index == otherVaults.length - 1}
                 withRoundedBorders={false}
                 icon={

--- a/src/shared/containers/SidebarV2/VaultSelector.test.tsx
+++ b/src/shared/containers/SidebarV2/VaultSelector.test.tsx
@@ -1,0 +1,278 @@
+import React, { isValidElement } from 'react'
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+import { VaultSelector } from './VaultSelector'
+import { CreateOrEditVaultModalContentV2 } from '../CreateOrEditVaultModalContentV2'
+import { ShareVaultModalContentV2 } from '../ShareVaultModalContentV2'
+
+const mockSetIsLoading = jest.fn()
+const mockSetModal = jest.fn()
+const mockCloseModal = jest.fn()
+const mockSwitchVault = jest.fn()
+const mockCreateInvite = jest.fn()
+
+jest.mock('./VaultSelector.styles', () => ({
+  VAULT_ACTIONS_MENU_WIDTH: 180,
+  createStyles: () => ({
+    wrapper: {},
+    titleRow: {},
+    titleLabel: {},
+    list: {},
+    vaultRow: {},
+    rowActions: {},
+    menuGroup: {},
+    iconActionButton: {}
+  })
+}))
+
+jest.mock('../../context/LoadingContext', () => ({
+  useLoadingContext: () => ({ setIsLoading: mockSetIsLoading })
+}))
+
+jest.mock('../../context/ModalContext', () => ({
+  useModal: () => ({
+    setModal: mockSetModal,
+    closeModal: mockCloseModal
+  })
+}))
+
+jest.mock('../../hooks/useVaultSwitch', () => ({
+  useVaultSwitch: () => ({ switchVault: mockSwitchVault })
+}))
+
+jest.mock('@tetherto/pearpass-lib-vault', () => ({
+  useVaults: jest.fn(),
+  useVault: jest.fn(),
+  useInvite: jest.fn()
+}))
+
+jest.mock('../CreateOrEditVaultModalContentV2', () => {
+  const R = require('react')
+  return {
+    CreateOrEditVaultModalContentV2: (props: Record<string, unknown>) =>
+      R.createElement('div', {
+        'data-testid': 'create-or-edit-vault-modal',
+        ...props
+      })
+  }
+})
+
+jest.mock('../ShareVaultModalContentV2', () => {
+  const R = require('react')
+  return {
+    ShareVaultModalContentV2: () =>
+      R.createElement('div', { 'data-testid': 'share-vault-modal' })
+  }
+})
+
+jest.mock('@lingui/core/macro', () => ({
+  t: (strings: TemplateStringsArray | string) =>
+    typeof strings === 'string' ? strings : strings[0]
+}))
+
+jest.mock('@tetherto/pearpass-lib-ui-kit/icons', () => ({
+  Add: () => <span data-testid="icon-add" />,
+  EditOutlined: () => <span data-testid="icon-edit" />,
+  LockFilled: () => <span data-testid="icon-lock" />,
+  MoreVert: () => <span data-testid="icon-more" />,
+  PersonAddAlt: () => <span data-testid="icon-person-add" />
+}))
+
+jest.mock('@tetherto/pearpass-lib-ui-kit', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        colorTextPrimary: '#111111',
+        colorTextSecondary: '#222222'
+      }
+    }
+  }),
+  Button: ({
+    children,
+    onClick,
+    'data-testid': dataTestId,
+    'aria-label': ariaLabel,
+    iconBefore
+  }: {
+    children?: React.ReactNode
+    onClick?: () => void
+    'data-testid'?: string
+    'aria-label'?: string
+    iconBefore?: React.ReactNode
+  }) => (
+    <button
+      type="button"
+      data-testid={dataTestId}
+      aria-label={ariaLabel}
+      onClick={onClick}
+    >
+      {iconBefore}
+      {children}
+    </button>
+  ),
+  ContextMenu: ({
+    trigger,
+    children
+  }: {
+    trigger: React.ReactNode
+    children: React.ReactNode
+  }) => (
+    <div data-testid="context-menu">
+      <div data-testid="context-menu-trigger">{trigger}</div>
+      <div data-testid="context-menu-panel">{children}</div>
+    </div>
+  ),
+  ListItem: ({
+    title,
+    onClick,
+    testID,
+    rightElement
+  }: {
+    title: string
+    onClick?: () => void
+    testID?: string
+    rightElement?: React.ReactNode
+  }) => (
+    <div data-testid={testID} role="presentation" onClick={onClick}>
+      <span>{title}</span>
+      {rightElement}
+    </div>
+  ),
+  NavbarListItem: ({
+    label,
+    onClick,
+    testID
+  }: {
+    label: string
+    onClick?: () => void
+    testID?: string
+  }) => (
+    <button type="button" data-testid={testID} onClick={onClick}>
+      {label}
+    </button>
+  ),
+  Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>
+}))
+
+import { useInvite, useVault, useVaults } from '@tetherto/pearpass-lib-vault'
+
+const mockUseVaults = useVaults as jest.Mock
+const mockUseVault = useVault as jest.Mock
+const mockUseInvite = useInvite as jest.Mock
+
+describe('VaultSelector', () => {
+  const vaultAlpha = { id: 'vault-alpha', name: 'Alpha' }
+  const vaultBeta = { id: 'vault-beta', name: 'Beta' }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSwitchVault.mockResolvedValue(undefined)
+    mockCreateInvite.mockResolvedValue(undefined)
+
+    mockUseVaults.mockReturnValue({
+      data: [vaultBeta, vaultAlpha]
+    })
+    mockUseVault.mockReturnValue({
+      data: vaultBeta
+    })
+    mockUseInvite.mockReturnValue({
+      data: { vaultId: vaultBeta.id },
+      createInvite: mockCreateInvite
+    })
+  })
+
+  it('renders the vault list sorted by name', () => {
+    render(<VaultSelector />)
+
+    const titles = screen.getAllByText(/Alpha|Beta/)
+    expect(titles.map((n) => n.textContent)).toEqual(['Alpha', 'Beta'])
+  })
+
+  it('calls switchVault when selecting a vault that is not active', () => {
+    render(<VaultSelector />)
+
+    fireEvent.click(screen.getByTestId(`vault-row-${vaultAlpha.id}`))
+
+    expect(mockSwitchVault).toHaveBeenCalledTimes(1)
+    expect(mockSwitchVault).toHaveBeenCalledWith(vaultAlpha)
+  })
+
+  it('does not call switchVault when clicking the active vault', () => {
+    render(<VaultSelector />)
+
+    fireEvent.click(screen.getByTestId(`vault-row-${vaultBeta.id}`))
+
+    expect(mockSwitchVault).not.toHaveBeenCalled()
+  })
+
+  it('opens create vault modal when create is clicked', () => {
+    render(<VaultSelector />)
+
+    fireEvent.click(screen.getByTestId('vault-selector-create'))
+
+    expect(mockSetModal).toHaveBeenCalledTimes(1)
+    const modal = mockSetModal.mock.calls[0][0] as React.ReactElement
+    expect(modal.type).toBe(CreateOrEditVaultModalContentV2)
+    expect(modal.props).toMatchObject({
+      onClose: mockCloseModal,
+      onSuccess: mockCloseModal
+    })
+  })
+
+  it('opens rename modal with the selected vault', () => {
+    render(<VaultSelector />)
+
+    fireEvent.click(screen.getByTestId(`vault-row-rename-${vaultBeta.id}`))
+
+    expect(mockSetModal).toHaveBeenCalledTimes(1)
+    const modal = mockSetModal.mock.calls[0][0] as React.ReactElement
+    expect(modal.type).toBe(CreateOrEditVaultModalContentV2)
+    expect(modal.props).toMatchObject({
+      vault: vaultBeta,
+      onClose: mockCloseModal,
+      onSuccess: mockCloseModal
+    })
+  })
+
+  it('skips createInvite when invite target already matches inviteData.vaultId, then opens share modal', async () => {
+    render(<VaultSelector />)
+
+    fireEvent.click(screen.getByTestId(`vault-row-invite-${vaultBeta.id}`))
+
+    await waitFor(() => {
+      expect(mockSetModal).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mockCreateInvite).not.toHaveBeenCalled()
+    expect(mockSetIsLoading).not.toHaveBeenCalled()
+    const shareNode = mockSetModal.mock.calls[0][0] as React.ReactElement
+    expect(isValidElement(shareNode)).toBe(true)
+    expect(shareNode.type).toBe(ShareVaultModalContentV2)
+  })
+
+  it('runs createInvite with loading when inviteData vault differs, then opens share modal', async () => {
+    mockUseInvite.mockReturnValue({
+      data: { vaultId: vaultAlpha.id },
+      createInvite: mockCreateInvite
+    })
+
+    render(<VaultSelector />)
+
+    fireEvent.click(screen.getByTestId(`vault-row-invite-${vaultBeta.id}`))
+
+    await waitFor(() => {
+      expect(mockCreateInvite).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mockSetIsLoading).toHaveBeenCalledWith(true)
+    expect(mockSetIsLoading).toHaveBeenLastCalledWith(false)
+    await waitFor(() => {
+      expect(mockSetModal).toHaveBeenCalledTimes(1)
+    })
+    const shareNode = mockSetModal.mock.calls[0][0] as React.ReactElement
+    expect(isValidElement(shareNode)).toBe(true)
+    expect(shareNode.type).toBe(ShareVaultModalContentV2)
+  })
+})

--- a/src/shared/containers/SidebarV2/VaultSelector.tsx
+++ b/src/shared/containers/SidebarV2/VaultSelector.tsx
@@ -28,26 +28,19 @@ import { createStyles, VAULT_ACTIONS_MENU_WIDTH } from './VaultSelector.styles'
 import { useLoadingContext } from '../../context/LoadingContext'
 import { useModal } from '../../context/ModalContext'
 import { sortByName } from '../../utils/sortByName'
+import { useVaultSwitch } from '../../hooks/useVaultSwitch'
 import { CreateOrEditVaultModalContentV2 } from '../CreateOrEditVaultModalContentV2'
 import { ShareVaultModalContentV2 } from '../ShareVaultModalContentV2'
-import { VaultPasswordFormModalContent } from '../VaultPasswordFormModalContent'
 
-type VaultSelectorProps = {
-  onClose?: () => void
-}
-
-export const VaultSelector = ({ onClose }: VaultSelectorProps) => {
+export const VaultSelector = () => {
   const { theme } = useTheme()
   const styles = createStyles(theme.colors)
   const { setIsLoading } = useLoadingContext()
   const { setModal, closeModal } = useModal()
 
   const { data: vaultsData } = useVaults()
-  const {
-    data: activeVault,
-    isVaultProtected,
-    refetch: refetchVault
-  } = useVault()
+  const { data: activeVault } = useVault()
+  const { switchVault } = useVaultSwitch()
   const { data: inviteData, createInvite } = useInvite()
 
   const vaults = useMemo<Vault[]>(
@@ -67,48 +60,7 @@ export const VaultSelector = ({ onClose }: VaultSelectorProps) => {
         setIsLoading(false)
       }
     }
-    onClose?.()
     setModal(<ShareVaultModalContentV2 />)
-  }
-
-  const switchVault = async (
-    vault: Vault,
-    onSuccess: () => void | Promise<void>
-  ) => {
-    setIsLoading(true)
-
-    try {
-      if (vault.id === activeVault?.id) {
-        await onSuccess()
-        return
-      }
-
-      const isProtected = await isVaultProtected(vault.id)
-
-      if (isProtected) {
-        setModal(
-          <VaultPasswordFormModalContent
-            vault={vault}
-            onSubmit={async (password: string) => {
-              setIsLoading(true)
-              try {
-                await refetchVault(vault.id, { password })
-                closeModal()
-                await onSuccess()
-              } finally {
-                setIsLoading(false)
-              }
-            }}
-          />
-        )
-        return
-      }
-
-      await refetchVault(vault.id)
-      await onSuccess()
-    } finally {
-      setIsLoading(false)
-    }
   }
 
   const handleCreate = () => {
@@ -121,23 +73,23 @@ export const VaultSelector = ({ onClose }: VaultSelectorProps) => {
   }
 
   const handleVaultClick = (vault: Vault) => {
-    void switchVault(vault, () => onClose?.())
+    if (vault.id !== activeVault?.id) {
+      void switchVault(vault)
+    }
   }
 
   const handleInvite = (vault: Vault) => {
-    void switchVault(vault, () => openInviteFlow(vault))
+    void openInviteFlow(vault)
   }
 
   const handleRename = (vault: Vault) => {
-    void switchVault(vault, () => {
-      setModal(
-        <CreateOrEditVaultModalContentV2
-          vault={vault}
-          onClose={closeModal}
-          onSuccess={closeModal}
-        />
-      )
-    })
+    setModal(
+      <CreateOrEditVaultModalContentV2
+        vault={vault}
+        onClose={closeModal}
+        onSuccess={closeModal}
+      />
+    )
   }
 
   return (
@@ -269,7 +221,7 @@ const VaultRow = ({
       style={styles.vaultRow as React.ComponentProps<typeof ListItem>['style']}
       testID={`vault-row-${vault.id}`}
       onClick={() => onSelect(vault)}
-      rightElement={rightElement}
+      rightElement={isActive ? rightElement : undefined}
     />
   )
 }

--- a/src/shared/containers/SidebarV2/index.tsx
+++ b/src/shared/containers/SidebarV2/index.tsx
@@ -239,9 +239,7 @@ export const SidebarV2 = () => {
 
       <div style={styles.scrollContainer}>
         <div style={styles.scrollArea}>
-          {isVaultSelectorOpen && (
-            <VaultSelector onClose={() => setIsVaultSelectorOpen(false)} />
-          )}
+          {isVaultSelectorOpen && <VaultSelector />}
 
           {!isVaultSelectorOpen && (
             <>

--- a/src/shared/hooks/useVaultSwitch.test.tsx
+++ b/src/shared/hooks/useVaultSwitch.test.tsx
@@ -1,0 +1,173 @@
+import { isValidElement } from 'react'
+
+import { act, renderHook } from '@testing-library/react'
+import { useVault, type Vault } from '@tetherto/pearpass-lib-vault'
+
+import { VaultPasswordFormModalContent } from '../containers/VaultPasswordFormModalContent'
+import { useLoadingContext } from '../context/LoadingContext'
+import { useModal } from '../context/ModalContext'
+import { logger } from '../utils/logger'
+
+import { useVaultSwitch } from './useVaultSwitch'
+
+jest.mock('@tetherto/pearpass-lib-vault', () => ({
+  useVault: jest.fn()
+}))
+
+jest.mock('../context/LoadingContext', () => ({
+  useLoadingContext: jest.fn()
+}))
+
+jest.mock('../context/ModalContext', () => ({
+  useModal: jest.fn()
+}))
+
+jest.mock('../containers/VaultPasswordFormModalContent', () => ({
+  VaultPasswordFormModalContent: jest.fn(() => null)
+}))
+
+jest.mock('../utils/logger', () => ({
+  logger: { error: jest.fn() }
+}))
+
+const mockUseVault = useVault as jest.Mock
+const mockUseLoadingContext = useLoadingContext as jest.Mock
+const mockUseModal = useModal as jest.Mock
+
+describe('useVaultSwitch', () => {
+  const mockSetIsLoading = jest.fn()
+  const mockSetModal = jest.fn()
+  const mockCloseModal = jest.fn()
+  const mockRefetchVault = jest.fn()
+  const mockIsVaultProtected = jest.fn()
+
+  const activeVault: Vault = { id: 'v-active', name: 'Active' }
+  const otherVault: Vault = { id: 'v-other', name: 'Other' }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockUseLoadingContext.mockReturnValue({ setIsLoading: mockSetIsLoading })
+    mockUseModal.mockReturnValue({
+      setModal: mockSetModal,
+      closeModal: mockCloseModal
+    })
+
+    mockUseVault.mockReturnValue({
+      data: activeVault,
+      isVaultProtected: mockIsVaultProtected,
+      refetch: mockRefetchVault
+    })
+  })
+
+  it('runs onSuccess and skips refetch when switching to the already active vault', async () => {
+    const onSuccess = jest.fn()
+
+    const { result } = renderHook(() => useVaultSwitch())
+
+    await act(async () => {
+      await result.current.switchVault(activeVault, onSuccess)
+    })
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(mockIsVaultProtected).not.toHaveBeenCalled()
+    expect(mockRefetchVault).not.toHaveBeenCalled()
+    expect(mockSetModal).not.toHaveBeenCalled()
+    expect(mockSetIsLoading).toHaveBeenCalledWith(true)
+    expect(mockSetIsLoading).toHaveBeenLastCalledWith(false)
+  })
+
+  it('refetches unprotected vault then runs onSuccess', async () => {
+    mockIsVaultProtected.mockResolvedValue(false)
+    mockRefetchVault.mockResolvedValue(undefined)
+    const onSuccess = jest.fn()
+
+    const { result } = renderHook(() => useVaultSwitch())
+
+    await act(async () => {
+      await result.current.switchVault(otherVault, onSuccess)
+    })
+
+    expect(mockIsVaultProtected).toHaveBeenCalledWith(otherVault.id)
+    expect(mockRefetchVault).toHaveBeenCalledWith(otherVault.id)
+    expect(mockRefetchVault).toHaveBeenCalledTimes(1)
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(mockSetModal).not.toHaveBeenCalled()
+    expect(mockSetIsLoading).toHaveBeenLastCalledWith(false)
+  })
+
+  it('opens password modal when target vault is protected (no refetch until submit)', async () => {
+    mockIsVaultProtected.mockResolvedValue(true)
+
+    const { result } = renderHook(() => useVaultSwitch())
+
+    await act(async () => {
+      await result.current.switchVault(otherVault)
+    })
+
+    expect(mockSetModal).toHaveBeenCalledTimes(1)
+    expect(mockRefetchVault).not.toHaveBeenCalled()
+    const modalElement = mockSetModal.mock.calls[0][0]
+    expect(isValidElement(modalElement)).toBe(true)
+    expect(modalElement.type).toBe(VaultPasswordFormModalContent)
+    expect(modalElement.props).toMatchObject({
+      vault: otherVault,
+      onSubmit: expect.any(Function)
+    })
+  })
+
+  it('refetches with password, closes modal, and runs onSuccess from modal onSubmit', async () => {
+    mockIsVaultProtected.mockResolvedValue(true)
+    mockRefetchVault.mockResolvedValue(undefined)
+    const onSuccess = jest.fn()
+
+    const { result } = renderHook(() => useVaultSwitch())
+
+    await act(async () => {
+      await result.current.switchVault(otherVault, onSuccess)
+    })
+
+    const modalElement = mockSetModal.mock.calls[0][0]
+    expect(isValidElement(modalElement)).toBe(true)
+    const { onSubmit } = modalElement.props as {
+      onSubmit: (password: string) => Promise<void>
+    }
+
+    await act(async () => {
+      await onSubmit('secret')
+    })
+
+    expect(mockRefetchVault).toHaveBeenCalledWith(otherVault.id, {
+      password: 'secret'
+    })
+    expect(mockCloseModal).toHaveBeenCalledTimes(1)
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs and rethrows when refetch fails', async () => {
+    mockIsVaultProtected.mockResolvedValue(false)
+    const err = new Error('refetch failed')
+    mockRefetchVault.mockRejectedValue(err)
+    const onSuccess = jest.fn()
+
+    const { result } = renderHook(() => useVaultSwitch())
+
+    let caught: unknown
+    await act(async () => {
+      try {
+        await result.current.switchVault(otherVault, onSuccess)
+      } catch (e) {
+        caught = e
+      }
+    })
+
+    expect(caught).toBe(err)
+    expect(logger.error).toHaveBeenCalledWith(
+      'useVaultSwitch',
+      'Error switching to vault:',
+      err
+    )
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(mockSetIsLoading).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/src/shared/hooks/useVaultSwitch.test.tsx
+++ b/src/shared/hooks/useVaultSwitch.test.tsx
@@ -6,6 +6,7 @@ import { useVault, type Vault } from '@tetherto/pearpass-lib-vault'
 import { VaultPasswordFormModalContent } from '../containers/VaultPasswordFormModalContent'
 import { useLoadingContext } from '../context/LoadingContext'
 import { useModal } from '../context/ModalContext'
+import { useToast } from '../context/ToastContext'
 import { logger } from '../utils/logger'
 
 import { useVaultSwitch } from './useVaultSwitch'
@@ -22,6 +23,10 @@ jest.mock('../context/ModalContext', () => ({
   useModal: jest.fn()
 }))
 
+jest.mock('../context/ToastContext', () => ({
+  useToast: jest.fn()
+}))
+
 jest.mock('../containers/VaultPasswordFormModalContent', () => ({
   VaultPasswordFormModalContent: jest.fn(() => null)
 }))
@@ -33,6 +38,7 @@ jest.mock('../utils/logger', () => ({
 const mockUseVault = useVault as jest.Mock
 const mockUseLoadingContext = useLoadingContext as jest.Mock
 const mockUseModal = useModal as jest.Mock
+const mockUseToast = useToast as jest.Mock
 
 describe('useVaultSwitch', () => {
   const mockSetIsLoading = jest.fn()
@@ -40,6 +46,7 @@ describe('useVaultSwitch', () => {
   const mockCloseModal = jest.fn()
   const mockRefetchVault = jest.fn()
   const mockIsVaultProtected = jest.fn()
+  const mockSetToast = jest.fn()
 
   const activeVault: Vault = { id: 'v-active', name: 'Active' }
   const otherVault: Vault = { id: 'v-other', name: 'Other' }
@@ -52,6 +59,7 @@ describe('useVaultSwitch', () => {
       setModal: mockSetModal,
       closeModal: mockCloseModal
     })
+    mockUseToast.mockReturnValue({ setToast: mockSetToast })
 
     mockUseVault.mockReturnValue({
       data: activeVault,
@@ -144,7 +152,7 @@ describe('useVaultSwitch', () => {
     expect(onSuccess).toHaveBeenCalledTimes(1)
   })
 
-  it('logs and rethrows when refetch fails', async () => {
+  it('logs and shows a toast when refetch fails', async () => {
     mockIsVaultProtected.mockResolvedValue(false)
     const err = new Error('refetch failed')
     mockRefetchVault.mockRejectedValue(err)
@@ -152,22 +160,47 @@ describe('useVaultSwitch', () => {
 
     const { result } = renderHook(() => useVaultSwitch())
 
-    let caught: unknown
     await act(async () => {
-      try {
-        await result.current.switchVault(otherVault, onSuccess)
-      } catch (e) {
-        caught = e
-      }
+      await result.current.switchVault(otherVault, onSuccess)
     })
 
-    expect(caught).toBe(err)
     expect(logger.error).toHaveBeenCalledWith(
       'useVaultSwitch',
       'Error switching to vault:',
       err
     )
+    expect(mockSetToast).toHaveBeenCalledWith({
+      message: expect.any(String)
+    })
     expect(onSuccess).not.toHaveBeenCalled()
     expect(mockSetIsLoading).toHaveBeenLastCalledWith(false)
+  })
+
+  it('throws when protected vault refetch fails after password submit', async () => {
+    mockIsVaultProtected.mockResolvedValue(true)
+    const err = new Error('protected refetch failed')
+    mockRefetchVault.mockRejectedValue(err)
+    const onSuccess = jest.fn()
+
+    const { result } = renderHook(() => useVaultSwitch())
+
+    await act(async () => {
+      await result.current.switchVault(otherVault, onSuccess)
+    })
+
+    const modalElement = mockSetModal.mock.calls[0][0]
+    const { onSubmit } = modalElement.props as {
+      onSubmit: (password: string) => Promise<void>
+    }
+
+    let caught: unknown
+    await act(async () => {
+      try {
+        await onSubmit('wrong')
+      } catch (e) {
+        caught = e
+      }
+    })
+    expect(caught).toBe(err)
   })
 })

--- a/src/shared/hooks/useVaultSwitch.tsx
+++ b/src/shared/hooks/useVaultSwitch.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from 'react'
+
+import { useVault, type Vault } from '@tetherto/pearpass-lib-vault'
+
+import { VaultPasswordFormModalContent } from '../containers/VaultPasswordFormModalContent'
+import { useLoadingContext } from '../context/LoadingContext'
+import { useModal } from '../context/ModalContext'
+import { logger } from '../utils/logger'
+
+/**
+ * Switch active vault with the same flow everywhere: optional password modal
+ * when the vault is protected, then `refetch` from `useVault` and an optional success callback.
+ */
+export function useVaultSwitch() {
+  const { setIsLoading } = useLoadingContext()
+  const { setModal, closeModal } = useModal()
+  const {
+    data: activeVault,
+    isVaultProtected,
+    refetch: refetchVault
+  } = useVault()
+
+  const switchVault = useCallback(
+    async (
+      vault: Vault,
+      onSuccess: () => void | Promise<void> = async () => {}
+    ) => {
+      setIsLoading(true)
+
+      try {
+        if (vault.id === activeVault?.id) {
+          await onSuccess()
+          return
+        }
+
+        const isProtected = await isVaultProtected(vault.id)
+
+        if (isProtected) {
+          setModal(
+            <VaultPasswordFormModalContent
+              vault={vault}
+              onSubmit={async (password: string) => {
+                setIsLoading(true)
+                try {
+                  await refetchVault(vault.id, { password })
+                  closeModal()
+                  await onSuccess()
+                } finally {
+                  setIsLoading(false)
+                }
+              }}
+            />
+          )
+          return
+        }
+
+        await refetchVault(vault.id)
+        await onSuccess()
+      } catch (error) {
+        logger.error('useVaultSwitch', 'Error switching to vault:', error)
+        throw error
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [activeVault?.id, closeModal, isVaultProtected, setIsLoading, setModal]
+  )
+
+  return { switchVault }
+}

--- a/src/shared/hooks/useVaultSwitch.tsx
+++ b/src/shared/hooks/useVaultSwitch.tsx
@@ -1,10 +1,12 @@
 import { useCallback } from 'react'
 
+import { t } from '@lingui/core/macro'
 import { useVault, type Vault } from '@tetherto/pearpass-lib-vault'
 
 import { VaultPasswordFormModalContent } from '../containers/VaultPasswordFormModalContent'
 import { useLoadingContext } from '../context/LoadingContext'
 import { useModal } from '../context/ModalContext'
+import { useToast } from '../context/ToastContext'
 import { logger } from '../utils/logger'
 
 /**
@@ -14,6 +16,9 @@ import { logger } from '../utils/logger'
 export function useVaultSwitch() {
   const { setIsLoading } = useLoadingContext()
   const { setModal, closeModal } = useModal()
+  const { setToast } = useToast() as {
+    setToast: (toast: { message: string }) => void
+  }
   const {
     data: activeVault,
     isVaultProtected,
@@ -45,6 +50,8 @@ export function useVaultSwitch() {
                   await refetchVault(vault.id, { password })
                   closeModal()
                   await onSuccess()
+                } catch (error) {
+                  throw error
                 } finally {
                   setIsLoading(false)
                 }
@@ -58,7 +65,9 @@ export function useVaultSwitch() {
         await onSuccess()
       } catch (error) {
         logger.error('useVaultSwitch', 'Error switching to vault:', error)
-        throw error
+        setToast({
+          message: t`Couldn't switch vault. Please try again.`
+        })
       } finally {
         setIsLoading(false)
       }


### PR DESCRIPTION
### Requirements
<!-- List the requirements for this PR -->


Header copy update: Change "Your Vaults" section text to: "Manage your vaults. Select the vault you want to apply changes to."
UI Constraint
Display action icons (Sharing and 3-dots menu) only for the currently active vault in both the navbar dropdown (left side) and in the settings → "your vaults" list
Hide all action icons for inactive vaults
Interaction: Ensure all inactive vault rows are fully clickable.
Navigation: Clicking an inactive vault must switch the active context to that vault
Experience: The vault switch must be seamless,  the user must remain on the current page/view without a reload or redirect, but the new "current vault" should be reflected to the selected one
Validation: Confirm the new active vault now displays the Sharing and 3-dots menu, while the previous vault hides them.
### Changes
<!-- Summarize the changes introduced in this PR -->

### Testing Notes
<!-- How did you test it? -->

### Things reviewers should pay attention to
<!-- Highlight anything specific you want reviewers to focus on -->

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/949a8db1-c85f-456b-9070-a37cd66c543b


### dependencies
<!-- List any dependent work items or PRs -->
