### PR TITLE
Fix content popup flicker on focus.

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -175,8 +175,8 @@ function handlePasswordSuggestionPopup(event) {
     styles: {
       top: `${rect.top + rect.height + 5}px`,
       left: `${rect.left + rect.width / 2}px`,
-      width: '300px',
-      height: '55px',
+      width: '0px',
+      height: '0px',
       borderRadius: '12px'
     }
   })
@@ -510,8 +510,8 @@ function showLogoForField(field) {
     styles: {
       top: `${rect.top + (rect.height - LOGO_SIZE) / 2}px`,
       left: `${rect.left + rect.width - LOGO_SIZE - LOGO_PADDING}px`,
-      width: `${LOGO_SIZE}px`,
-      height: `${LOGO_SIZE}px`,
+      width: '0px',
+      height: '0px',
       borderRadius: '50%'
     }
   })

--- a/src/contentPopups/iframeApi/setIframeStyles.js
+++ b/src/contentPopups/iframeApi/setIframeStyles.js
@@ -1,0 +1,20 @@
+/**
+ *
+ * @param {Object} params
+ * @param {string} params.iframeId
+ * @param {string} params.iframeType
+ * @param {Object} params.style
+ */
+export const setIframeStyles = ({ iframeId, iframeType, style }) => {
+  window.parent.postMessage(
+    {
+      type: 'setStyles',
+      data: {
+        iframeId,
+        iframeType,
+        style
+      }
+    },
+    '*'
+  )
+}

--- a/src/contentPopups/iframeApi/setIframeStyles.test.js
+++ b/src/contentPopups/iframeApi/setIframeStyles.test.js
@@ -1,0 +1,47 @@
+import { setIframeStyles } from './setIframeStyles'
+
+describe('setIframeStyles', () => {
+  beforeEach(() => {
+    jest.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should send the correct data object with iframeId, iframeType and style', () => {
+    const iframeId = 'testIframeId'
+    const iframeType = 'testIframeType'
+    const style = { width: '300px', height: '55px', borderRadius: '12px' }
+
+    setIframeStyles({ iframeId, iframeType, style })
+
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      {
+        type: 'setStyles',
+        data: {
+          iframeId,
+          iframeType,
+          style
+        }
+      },
+      '*'
+    )
+  })
+
+  it('should handle missing iframeId, iframeType and style gracefully', () => {
+    setIframeStyles({})
+
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      {
+        type: 'setStyles',
+        data: {
+          iframeId: undefined,
+          iframeType: undefined,
+          style: undefined
+        }
+      },
+      '*'
+    )
+  })
+})

--- a/src/contentPopups/views/Autofill/index.jsx
+++ b/src/contentPopups/views/Autofill/index.jsx
@@ -10,6 +10,7 @@ import { UserKeyIcon } from '../../../shared/icons/UserKeyIcon'
 import { MESSAGE_TYPES } from '../../../shared/services/messageBridge'
 import { logger } from '../../../shared/utils/logger'
 import { useFilteredRecords } from '../../hooks/useFilteredRecords'
+import { setIframeStyles } from '../../iframeApi/setIframeStyles'
 
 export const Autofill = () => {
   const popupRef = useRef(null)
@@ -85,21 +86,15 @@ export const Autofill = () => {
     requestAnimationFrame(() => {
       if (!popupRef.current) return
 
-      window.parent.postMessage(
-        {
-          type: 'setStyles',
-          data: {
-            iframeId: routerState?.iframeId,
-            iframeType: routerState?.iframeType,
-            style: {
-              width: `${popupRef.current.offsetWidth}px`,
-              height: `${popupRef.current.offsetHeight}px`,
-              borderRadius: '12px'
-            }
-          }
-        },
-        '*'
-      )
+      setIframeStyles({
+        iframeId: routerState?.iframeId,
+        iframeType: routerState?.iframeType,
+        style: {
+          width: `${popupRef.current.offsetWidth}px`,
+          height: `${popupRef.current.offsetHeight}px`,
+          borderRadius: '12px'
+        }
+      })
     })
   }, [
     routerState?.iframeId,

--- a/src/contentPopups/views/LoginDetect/index.jsx
+++ b/src/contentPopups/views/LoginDetect/index.jsx
@@ -20,6 +20,7 @@ import { UserIcon } from '../../../shared/icons/UserIcon'
 import { extractNameFromDomain } from '../../../shared/utils/extractNameFromDomain'
 import { CardButtons } from '../../containers/CardButtons'
 import { closeIframe } from '../../iframeApi/closeIframe'
+import { setIframeStyles } from '../../iframeApi/setIframeStyles'
 
 export const LoginDetect = () => {
   const { state: routerState } = useRouter()
@@ -99,21 +100,15 @@ export const LoginDetect = () => {
   }
 
   useEffect(() => {
-    window.parent.postMessage(
-      {
-        type: 'setStyles',
-        data: {
-          iframeId: routerState?.iframeId,
-          iframeType: routerState?.iframeType,
-          style: {
-            width: `${popupRef.current?.offsetWidth}px`,
-            height: `${popupRef.current?.offsetHeight}px`,
-            borderRadius: '12px'
-          }
-        }
-      },
-      '*'
-    )
+    setIframeStyles({
+      iframeId: routerState?.iframeId,
+      iframeType: routerState?.iframeType,
+      style: {
+        width: `${popupRef.current?.offsetWidth}px`,
+        height: `${popupRef.current?.offsetHeight}px`,
+        borderRadius: '12px'
+      }
+    })
 
     refetchVault()
   }, [!!existingRecord])

--- a/src/contentPopups/views/Logo/index.jsx
+++ b/src/contentPopups/views/Logo/index.jsx
@@ -6,6 +6,7 @@ import { useRouter } from '../../../shared/context/RouterContext'
 import { LogoLock } from '../../../shared/svgs/logoLock'
 import { useFilteredRecords } from '../../hooks/useFilteredRecords'
 import { closeIframe } from '../../iframeApi/closeIframe'
+import { setIframeStyles } from '../../iframeApi/setIframeStyles'
 
 export const Logo = () => {
   const { state: routerState } = useRouter()
@@ -15,6 +16,8 @@ export const Logo = () => {
   const { filteredRecords, isInitialized, isLoading } = useFilteredRecords()
 
   const count = filteredRecords?.length || 0
+  const isReady = isInitialized && !isLoading
+  const shouldShowLogo = isReady && count > 0
 
   const handleClick = () => {
     window.parent.postMessage(
@@ -30,17 +33,33 @@ export const Logo = () => {
   }
 
   useEffect(() => {
-    if (!filteredRecords?.length && !isLoading && isInitialized) {
+    refetchVault()
+  }, [])
+
+  useEffect(() => {
+    if (isReady && !count) {
       closeIframe({
         iframeId: routerState?.iframeId,
         iframeType: routerState?.iframeType
       })
     }
+  }, [isReady, count])
 
-    refetchVault()
-  }, [filteredRecords?.length, isInitialized])
+  useEffect(() => {
+    if (!shouldShowLogo) return
 
-  if (isLoading || !isInitialized || !count) {
+    setIframeStyles({
+      iframeId: routerState?.iframeId,
+      iframeType: routerState?.iframeType,
+      style: {
+        width: '30px',
+        height: '30px',
+        borderRadius: '50%'
+      }
+    })
+  }, [shouldShowLogo])
+
+  if (!shouldShowLogo) {
     return null
   }
 

--- a/src/contentPopups/views/PasswordGenerator/index.jsx
+++ b/src/contentPopups/views/PasswordGenerator/index.jsx
@@ -7,6 +7,7 @@ import { PopupCard } from '../../../shared/components/PopupCard'
 import { PasswordGeneratorModalContent } from '../../../shared/containers/PasswordGeneratorModalContent'
 import { useRouter } from '../../../shared/context/RouterContext'
 import { closeIframe } from '../../iframeApi/closeIframe'
+import { setIframeStyles } from '../../iframeApi/setIframeStyles'
 
 export const PasswordGenerator = () => {
   const popupRef = useRef(null)
@@ -37,21 +38,15 @@ export const PasswordGenerator = () => {
   }
 
   useEffect(() => {
-    window.parent.postMessage(
-      {
-        type: 'setStyles',
-        data: {
-          iframeId: routerState?.iframeId,
-          iframeType: routerState?.iframeType,
-          style: {
-            width: `${popupRef.current?.offsetWidth}px`,
-            height: `${popupRef.current?.offsetHeight}px`,
-            borderRadius: '12px'
-          }
-        }
-      },
-      '*'
-    )
+    setIframeStyles({
+      iframeId: routerState?.iframeId,
+      iframeType: routerState?.iframeType,
+      style: {
+        width: `${popupRef.current?.offsetWidth}px`,
+        height: `${popupRef.current?.offsetHeight}px`,
+        borderRadius: '12px'
+      }
+    })
 
     refetchVault()
   }, [recordsData?.length])

--- a/src/contentPopups/views/PasswordGeneratorV2/index.tsx
+++ b/src/contentPopups/views/PasswordGeneratorV2/index.tsx
@@ -7,6 +7,7 @@ import { useRecords, useVault } from '@tetherto/pearpass-lib-vault'
 import { useRouter } from '../../../shared/context/RouterContext'
 import { PasswordGeneratorV2 as PasswordGeneratorV2Body } from '../../../shared/containers/PasswordGeneratorV2'
 import { closeIframe } from '../../iframeApi/closeIframe'
+import { setIframeStyles } from '../../iframeApi/setIframeStyles'
 
 export const PasswordGeneratorV2 = () => {
   const popupRef = useRef<HTMLDivElement>(null)
@@ -46,21 +47,15 @@ export const PasswordGeneratorV2 = () => {
 
   useLayoutEffect(() => {
     const el = popupRef.current
-    window.parent.postMessage(
-      {
-        type: 'setStyles',
-        data: {
-          iframeId: routerState?.iframeId,
-          iframeType: routerState?.iframeType,
-          style: {
-            width: `${el?.offsetWidth ?? 440}px`,
-            height: `${el?.offsetHeight ?? 280}px`,
-            borderRadius: '12px'
-          }
-        }
-      },
-      '*'
-    )
+    setIframeStyles({
+      iframeId: routerState?.iframeId,
+      iframeType: routerState?.iframeType,
+      style: {
+        width: `${el?.offsetWidth ?? 440}px`,
+        height: `${el?.offsetHeight ?? 280}px`,
+        borderRadius: '12px'
+      }
+    })
   }, [generated, routerState?.iframeId, routerState?.iframeType])
 
   useEffect(() => {

--- a/src/contentPopups/views/PasswordSuggestion/index.jsx
+++ b/src/contentPopups/views/PasswordSuggestion/index.jsx
@@ -12,6 +12,7 @@ import { KeyIcon } from '../../../shared/icons/KeyIcon'
 import { PasswordIcon } from '../../../shared/icons/PasswordIcon'
 import { useFilteredRecords } from '../../hooks/useFilteredRecords'
 import { closeIframe } from '../../iframeApi/closeIframe'
+import { setIframeStyles } from '../../iframeApi/setIframeStyles'
 
 export const PasswordSuggestion = () => {
   const popupRef = useRef(null)
@@ -23,6 +24,10 @@ export const PasswordSuggestion = () => {
   const { filteredRecords, isInitialized, isLoading } = useFilteredRecords()
 
   const password = useMemo(() => generatePassword(24), [])
+
+  const isReady = isInitialized && !isLoading
+  const hasMatchingRecords = !!filteredRecords?.length
+  const shouldShowSuggestion = isReady && !hasMatchingRecords
 
   const onPasswordInsert = (value) => {
     window.parent.postMessage(
@@ -45,31 +50,35 @@ export const PasswordSuggestion = () => {
   }
 
   useEffect(() => {
-    window.parent.postMessage(
-      {
-        type: 'setStyles',
-        data: {
-          iframeId: routerState?.iframeId,
-          iframeType: routerState?.iframeType,
-          style: {
-            width: `${popupRef.current?.offsetWidth}px`,
-            height: `${popupRef.current?.offsetHeight}px`,
-            borderRadius: '12px'
-          }
-        }
-      },
-      '*'
-    )
+    refetchVault()
+  }, [])
 
-    if (filteredRecords?.length && !isLoading && isInitialized) {
+  useEffect(() => {
+    if (isReady && hasMatchingRecords) {
       closeIframe({
         iframeId: routerState?.iframeId,
         iframeType: routerState?.iframeType
       })
     }
+  }, [isReady, hasMatchingRecords])
 
-    refetchVault()
-  }, [filteredRecords?.length])
+  useEffect(() => {
+    if (!shouldShowSuggestion) return
+
+    setIframeStyles({
+      iframeId: routerState?.iframeId,
+      iframeType: routerState?.iframeType,
+      style: {
+        width: `${popupRef.current?.offsetWidth}px`,
+        height: `${popupRef.current?.offsetHeight}px`,
+        borderRadius: '12px'
+      }
+    })
+  }, [shouldShowSuggestion])
+
+  if (!shouldShowSuggestion) {
+    return null
+  }
 
   return (
     <PopupCard

--- a/src/contentPopups/views/PasswordSuggestionV2/index.tsx
+++ b/src/contentPopups/views/PasswordSuggestionV2/index.tsx
@@ -11,6 +11,7 @@ import { Key, SyncLock } from '@tetherto/pearpass-lib-ui-kit/icons'
 import { useRouter } from '../../../shared/context/RouterContext'
 import { useFilteredRecords } from '../../hooks/useFilteredRecords'
 import { closeIframe } from '../../iframeApi/closeIframe'
+import { setIframeStyles } from '../../iframeApi/setIframeStyles'
 
 export const PasswordSuggestionV2 = () => {
   const popupRef = useRef<HTMLDivElement>(null)
@@ -21,6 +22,10 @@ export const PasswordSuggestionV2 = () => {
   const { filteredRecords, isInitialized, isLoading } = useFilteredRecords()
 
   const [password] = useState(() => generatePassword(24))
+
+  const isReady = isInitialized && !isLoading
+  const hasMatchingRecords = !!filteredRecords?.length
+  const shouldShowSuggestion = isReady && !hasMatchingRecords
 
   const onPasswordInsert = (value: string) => {
     window.parent.postMessage(
@@ -37,31 +42,31 @@ export const PasswordSuggestionV2 = () => {
   }
 
   useEffect(() => {
-    window.parent.postMessage(
-      {
-        type: 'setStyles',
-        data: {
-          iframeId: routerState?.iframeId,
-          iframeType: routerState?.iframeType,
-          style: {
-            width: `${popupRef.current?.offsetWidth}px`,
-            height: `${popupRef.current?.offsetHeight}px`,
-            borderRadius: '12px'
-          }
-        }
-      },
-      '*'
-    )
+    refetchVault()
+  }, [])
 
-    if (filteredRecords?.length && !isLoading && isInitialized) {
+  useEffect(() => {
+    if (isReady && hasMatchingRecords) {
       closeIframe({
         iframeId: routerState?.iframeId,
         iframeType: routerState?.iframeType
       })
     }
+  }, [isReady, hasMatchingRecords])
 
-    refetchVault()
-  }, [filteredRecords?.length])
+  useEffect(() => {
+    if (!shouldShowSuggestion) return
+
+    setIframeStyles({
+      iframeId: routerState?.iframeId,
+      iframeType: routerState?.iframeType,
+      style: {
+        width: `${popupRef.current?.offsetWidth}px`,
+        height: `${popupRef.current?.offsetHeight}px`,
+        borderRadius: '12px'
+      }
+    })
+  }, [shouldShowSuggestion])
 
   const onGeneratePassword = () => {
     navigate('passwordGenerator', {
@@ -72,6 +77,11 @@ export const PasswordSuggestionV2 = () => {
       state: Record<string, unknown>
     })
   }
+
+  if (!shouldShowSuggestion) {
+    return null
+  }
+
   return (
     <div
       ref={popupRef}


### PR DESCRIPTION
### Changes

- Hide the focus logo and password suggestion iframes (0x0) until the records check finishes, killing the flash on field focus.
- Gate `Logo` and `PasswordSuggestion[V2]` rendering on records being loaded; close the iframe instead of mounting then unmounting.
- Split the do-everything `useEffect` in each view into focused effects (mount-only refetch, close-on-decision, set-styles-on-show).
- Extract `iframeApi/setIframeStyles` helper (mirrors `closeIframe`) and migrate all 8 call sites to drop duplicated postMessage plumbing.
- Add unit tests for the new helper.

### Screenshots/Recordings

https://github.com/user-attachments/assets/07e45487-e108-4d60-b21c-9dee108a7c76