### PR TITLE
Removed max width from sync failed block onboarding

### DIFF
--- a/src/onboarding/SyncingFailedModal.tsx
+++ b/src/onboarding/SyncingFailedModal.tsx
@@ -40,7 +40,7 @@ export const SyncingFailedModal = ({
   return (
     <div
       data-testid={TEST_IDS.root}
-      className="bg-surface-primary flex w-full max-w-[500px] flex-col gap-[var(--spacing24)] rounded-[var(--radius8)] p-[var(--spacing24)]"
+      className="bg-surface-primary flex w-full flex-col gap-[var(--spacing24)] rounded-[var(--radius8)] p-[var(--spacing24)]"
     >
       <div className="flex flex-col items-center gap-[var(--spacing8)] text-center">
         <Title as="h2">


### PR DESCRIPTION
### Changes

Removed max width from sync failed block onboarding

### Screenshots/Recordings

<img width="1470" height="795" alt="Screenshot 2026-05-05 at 15 54 22" src="https://github.com/user-attachments/assets/d5932550-090f-4801-9e8a-35d16ba6d610" />
