### PR TITLE
Atomic pairing

### DIFF
--- a/src/action/containers/Modal/PairingRequiredModalContent/PairingRequiredModalContentV2.tsx
+++ b/src/action/containers/Modal/PairingRequiredModalContent/PairingRequiredModalContentV2.tsx
@@ -93,6 +93,15 @@ export const PairingRequiredModalContentV2 = ({
     return () => clearTimeout(timer)
   }, [error])
 
+  useEffect(() => {
+    if (!passwordError) return
+    const timer = setTimeout(async () => {
+      await openOnboardingPage()
+      window.close()
+    }, 2000)
+    return () => clearTimeout(timer)
+  }, [passwordError])
+
   if (missingToken) {
     return (
       <div

--- a/src/action/containers/Modal/PairingRequiredModalContent/PairingRequiredModalContentV2.tsx
+++ b/src/action/containers/Modal/PairingRequiredModalContent/PairingRequiredModalContentV2.tsx
@@ -18,7 +18,12 @@ export async function openOnboardingPage() {
 
   const isCurrentTabOnboarding = currentTab?.url?.includes('onboarding.html')
 
-  if (isCurrentTabOnboarding) return
+  if (isCurrentTabOnboarding) {
+    if (currentTab?.id !== undefined) {
+      await chrome.tabs.reload(currentTab.id)
+    }
+    return
+  }
 
   const allExtensionTabs = await chrome.tabs.query({
     url: chrome.runtime.getURL('*')
@@ -29,7 +34,10 @@ export async function openOnboardingPage() {
   )
 
   if (existingOnboardingTab) {
-    await chrome.tabs.update(existingOnboardingTab.id, { active: true })
+    if (existingOnboardingTab.id !== undefined) {
+      await chrome.tabs.reload(existingOnboardingTab.id)
+      await chrome.tabs.update(existingOnboardingTab.id, { active: true })
+    }
     if (existingOnboardingTab.windowId) {
       await chrome.windows.update(existingOnboardingTab.windowId, {
         focused: true

--- a/src/action/containers/Modal/PairingRequiredModalContent/openOnboardingPage.test.ts
+++ b/src/action/containers/Modal/PairingRequiredModalContent/openOnboardingPage.test.ts
@@ -36,7 +36,8 @@ const setupChromeMock = ({
           return Promise.resolve(allExtensionTabs)
         }),
       update: jest.fn().mockResolvedValue({}),
-      create: jest.fn().mockResolvedValue({})
+      create: jest.fn().mockResolvedValue({}),
+      reload: jest.fn().mockResolvedValue(undefined)
     },
     windows: {
       update: jest.fn().mockResolvedValue({})
@@ -49,19 +50,20 @@ describe('openOnboardingPage', () => {
     jest.clearAllMocks()
   })
 
-  it('does nothing when current tab is already onboarding', async () => {
+  it('reloads the current tab when it is already onboarding', async () => {
     setupChromeMock({
-      currentTab: { url: ONBOARDING_URL },
+      currentTab: { id: 7, url: ONBOARDING_URL },
       allExtensionTabs: []
     })
 
     await openOnboardingPage()
 
+    expect(chrome.tabs.reload).toHaveBeenCalledWith(7)
     expect(chrome.tabs.create).not.toHaveBeenCalled()
     expect(chrome.tabs.update).not.toHaveBeenCalled()
   })
 
-  it('focuses existing onboarding tab when one already exists', async () => {
+  it('reloads and focuses an existing onboarding tab in another window', async () => {
     const existingTab = { id: 42, url: ONBOARDING_URL, windowId: 99 }
 
     setupChromeMock({
@@ -71,6 +73,7 @@ describe('openOnboardingPage', () => {
 
     await openOnboardingPage()
 
+    expect(chrome.tabs.reload).toHaveBeenCalledWith(42)
     expect(chrome.tabs.update).toHaveBeenCalledWith(42, { active: true })
     expect(chrome.windows.update).toHaveBeenCalledWith(99, { focused: true })
     expect(chrome.tabs.create).not.toHaveBeenCalled()
@@ -86,9 +89,10 @@ describe('openOnboardingPage', () => {
 
     expect(chrome.tabs.create).toHaveBeenCalledWith({ url: ONBOARDING_URL })
     expect(chrome.tabs.update).not.toHaveBeenCalled()
+    expect(chrome.tabs.reload).not.toHaveBeenCalled()
   })
 
-  it('focuses existing tab but skips window focus when windowId is missing', async () => {
+  it('reloads and focuses existing tab but skips window focus when windowId is missing', async () => {
     const existingTab = { id: 42, url: ONBOARDING_URL }
 
     setupChromeMock({
@@ -98,6 +102,7 @@ describe('openOnboardingPage', () => {
 
     await openOnboardingPage()
 
+    expect(chrome.tabs.reload).toHaveBeenCalledWith(42)
     expect(chrome.tabs.update).toHaveBeenCalledWith(42, { active: true })
     expect(chrome.windows.update).not.toHaveBeenCalled()
   })

--- a/src/background/clientKeyStore.js
+++ b/src/background/clientKeyStore.js
@@ -13,6 +13,7 @@ const KEY_ID = 'client-ed25519'
 
 let inMemoryKeypair = null
 let pendingKeypair = null
+let pendingPersistRecord = null
 let unlocking = false
 
 const textEncoder = new TextEncoder()
@@ -219,16 +220,14 @@ const unlockKeypair = async (masterPassword) => {
   const record = await getKeyRecord(db)
 
   if (!record) {
-    // If we previously generated a pending keypair for pairing, persist that
-    // exact keypair so that the desktop's pinned client public key matches the
-    // private key we will use for signing.
+    // First-time pairing: build the encrypted record but hold it in memory.
+    // Caller must call commitPendingClientKeystore() after vault validation.
     let privateKey
     let publicKey
 
     if (pendingKeypair) {
       ;({ privateKey, publicKey } = pendingKeypair)
     } else {
-      // Generate new Ed25519 keypair
       privateKey = ed25519.utils.randomPrivateKey()
       publicKey = ed25519.getPublicKey(privateKey)
     }
@@ -238,7 +237,7 @@ const unlockKeypair = async (masterPassword) => {
       masterPassword
     )
 
-    const newRecord = {
+    pendingPersistRecord = {
       id: KEY_ID,
       publicKeyB64: base64Encode(publicKey),
       saltB64: base64Encode(salt),
@@ -246,8 +245,6 @@ const unlockKeypair = async (masterPassword) => {
       ciphertextB64: base64Encode(ciphertext),
       createdAt: new Date().toISOString()
     }
-
-    await putKeyRecord(db, newRecord)
 
     pendingKeypair = null
     inMemoryKeypair = { publicKey, privateKey }
@@ -264,6 +261,20 @@ const unlockKeypair = async (masterPassword) => {
     logger.log('[ClientKeyStore]', 'Failed to decrypt client keypair')
     throw new Error(AUTH_ERROR_PATTERNS.MASTER_PASSWORD_INVALID)
   }
+}
+
+/**
+ * Persist the pending keystore record from unlockKeypair's no-record branch.
+ * No-op if nothing is pending. Call only after the vault has accepted the
+ * master password, so an unverified password never lands on disk.
+ *
+ * @returns {Promise<void>}
+ */
+export const commitPendingClientKeystore = async () => {
+  if (!pendingPersistRecord) return
+  const db = await openDb()
+  await putKeyRecord(db, pendingPersistRecord)
+  pendingPersistRecord = null
 }
 
 /**
@@ -337,6 +348,8 @@ export const clearClientKeypair = async () => {
 
   secureZero(pendingKeypair?.privateKey)
   pendingKeypair = null
+
+  pendingPersistRecord = null
 
   // Reset unlocking flag to cancel any in-progress unlock
   unlocking = false

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,6 +1,9 @@
 import './nativeMessaging'
 
-import { ensureClientKeypairUnlocked } from './clientKeyStore'
+import {
+  ensureClientKeypairUnlocked,
+  commitPendingClientKeystore
+} from './clientKeyStore'
 import { MESSAGES, ALARMS } from './constants'
 import { secureChannel } from './secureChannel'
 import * as CredentialGenerator from './utils/credentialGenerator'
@@ -466,6 +469,22 @@ runtime.onMessage.addListener((msg, sender, sendResponse) => {
             success: false,
             error: e?.message,
             code: ERROR_CODES.AUTHENTICATION_FAILED
+          })
+        }
+      })()
+      return true
+    }
+
+    case SECURE_MESSAGE_TYPES.COMMIT_CLIENT_KEYSTORE: {
+      void (async () => {
+        try {
+          await commitPendingClientKeystore()
+          sendResponse({ success: true })
+        } catch (e) {
+          sendResponse({
+            success: false,
+            error: e?.message,
+            code: ERROR_CODES.UNKNOWN
           })
         }
       })()

--- a/src/background/secureChannel.js
+++ b/src/background/secureChannel.js
@@ -74,7 +74,6 @@ const secretboxOpen = (ciphertext, nonce, key) => {
 }
 
 const STORAGE_KEYS = Object.freeze({
-  paired: 'nm.paired',
   fingerprint: 'nm.fingerprint',
   ed25519PublicKey: 'nm.ed25519PublicKey',
   x25519PublicKey: 'nm.x25519PublicKey',
@@ -377,8 +376,7 @@ export class SecureChannelClient {
     const res = await storageGet([
       STORAGE_KEYS.fingerprint,
       STORAGE_KEYS.ed25519PublicKey,
-      STORAGE_KEYS.x25519PublicKey,
-      STORAGE_KEYS.paired
+      STORAGE_KEYS.x25519PublicKey
     ])
     const fingerprint = res[STORAGE_KEYS.fingerprint]
     const ed25519PublicKey = res[STORAGE_KEYS.ed25519PublicKey]
@@ -403,8 +401,7 @@ export class SecureChannelClient {
     await storageSet({
       [STORAGE_KEYS.fingerprint]: id.fingerprint,
       [STORAGE_KEYS.ed25519PublicKey]: id.ed25519PublicKey,
-      [STORAGE_KEYS.x25519PublicKey]: id.x25519PublicKey,
-      [STORAGE_KEYS.paired]: true
+      [STORAGE_KEYS.x25519PublicKey]: id.x25519PublicKey
     })
   }
 
@@ -416,8 +413,7 @@ export class SecureChannelClient {
     await storageSet({
       [STORAGE_KEYS.fingerprint]: undefined,
       [STORAGE_KEYS.ed25519PublicKey]: undefined,
-      [STORAGE_KEYS.x25519PublicKey]: undefined,
-      [STORAGE_KEYS.paired]: false
+      [STORAGE_KEYS.x25519PublicKey]: undefined
     })
     await clearClientKeypair()
   }

--- a/src/hooks/useDesktopPairing.js
+++ b/src/hooks/useDesktopPairing.js
@@ -213,9 +213,16 @@ export const useDesktopPairing = ({
       throw new Error(PAIRING_ERROR_MESSAGES.PAIRING_FAILED)
     }
 
-    // Validate password and initialize vaults
-    await logIn({ password })
-    await initVaults({ password })
+    // Validate password via vault, then commit the keystore. Roll back on
+    // failure so a wrong password never persists pairing state or keystore.
+    try {
+      await logIn({ password })
+      await initVaults({ password })
+      await secureChannelMessages.commitClientKeystore()
+    } catch (err) {
+      await secureChannelMessages.unpair()
+      throw err
+    }
 
     await pendingPairingStore.clear()
     setToast({ message: t`Paired successfully!` })

--- a/src/hooks/useDesktopPairing.js
+++ b/src/hooks/useDesktopPairing.js
@@ -215,12 +215,15 @@ export const useDesktopPairing = ({
 
     // Validate password via vault, then commit the keystore. Roll back on
     // failure so a wrong password never persists pairing state or keystore.
+    // Also drop the pending token: it has been consumed by confirmPair and
+    // the user must start again from the onboarding token-entry step.
     try {
       await logIn({ password })
       await initVaults({ password })
       await secureChannelMessages.commitClientKeystore()
     } catch (err) {
       await secureChannelMessages.unpair()
+      await pendingPairingStore.clear()
       throw err
     }
 

--- a/src/hooks/useDesktopPairing.js
+++ b/src/hooks/useDesktopPairing.js
@@ -21,7 +21,8 @@ const PAIRING_ERROR_MESSAGES = {
   FAILED_TO_GET_IDENTITY:
     'Failed to get identity. Please ensure the desktop app is running.',
   PAIRING_FAILED: 'Pairing failed',
-  INVALID_PASSWORD: 'Invalid master password. Please try again.'
+  INVALID_PASSWORD:
+    'Invalid master password. Pairing was reset, returning to onboarding...'
 }
 
 /**
@@ -264,7 +265,7 @@ export const useDesktopPairing = ({
         error.message === PAIRING_ERROR_MESSAGES.PAIRING_FAILED
       const message = isPairingFailed
         ? t`Pairing failed`
-        : t`Invalid master password. Please try again.`
+        : t`Invalid master password. Pairing was reset, returning to onboarding...`
       if (isPairingFailed) {
         setToast({ message })
       } else {

--- a/src/hooks/useDesktopPairing.storage.test.js
+++ b/src/hooks/useDesktopPairing.storage.test.js
@@ -150,6 +150,9 @@ describe('useDesktopPairing — storage behavior', () => {
         success: true
       })
       secureChannelMessages.pinIdentity.mockResolvedValue({ success: true })
+      secureChannelMessages.commitClientKeystore.mockResolvedValue({
+        success: true
+      })
 
       const { result, cleanup } = renderHook(() => useDesktopPairing(props))
 

--- a/src/hooks/useDesktopPairing.test.js
+++ b/src/hooks/useDesktopPairing.test.js
@@ -5,10 +5,18 @@ import { useDesktopPairing, PAIRING_STEP } from './useDesktopPairing.js'
 import { AUTH_ERROR_PATTERNS } from '../shared/constants/auth'
 import { useToast } from '../shared/context/ToastContext'
 import { secureChannelMessages } from '../shared/services/messageBridge'
+import { pendingPairingStore } from '../shared/services/pendingPairingStore'
 
 jest.mock('@tetherto/pearpass-lib-vault')
 jest.mock('../shared/context/ToastContext')
 jest.mock('../shared/services/messageBridge')
+jest.mock('../shared/services/pendingPairingStore', () => ({
+  pendingPairingStore: {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    clear: jest.fn().mockResolvedValue(undefined)
+  }
+}))
 jest.mock('../shared/utils/logger')
 jest.mock('@lingui/core/macro', () => ({
   t: (str) => {
@@ -216,6 +224,7 @@ describe('usePairing', () => {
       expect(mockLogIn).toHaveBeenCalledWith({ password: 'wrong-password' })
       expect(secureChannelMessages.commitClientKeystore).not.toHaveBeenCalled()
       expect(secureChannelMessages.unpair).toHaveBeenCalled()
+      expect(pendingPairingStore.clear).toHaveBeenCalled()
       expect(mockOnPairSuccess).not.toHaveBeenCalled()
       expect(result.current.passwordError).toEqual(
         expect.stringContaining('Invalid master password')

--- a/src/hooks/useDesktopPairing.test.js
+++ b/src/hooks/useDesktopPairing.test.js
@@ -147,6 +147,9 @@ describe('usePairing', () => {
         success: true
       })
       secureChannelMessages.pinIdentity.mockResolvedValue({ success: true })
+      secureChannelMessages.commitClientKeystore.mockResolvedValue({
+        success: true
+      })
 
       const { result } = renderHook(() => useDesktopPairing(props))
 
@@ -173,7 +176,50 @@ describe('usePairing', () => {
       )
       expect(mockLogIn).toHaveBeenCalledWith({ password: 'password' })
       expect(mockInitVaults).toHaveBeenCalledWith({ password: 'password' })
+      expect(secureChannelMessages.commitClientKeystore).toHaveBeenCalled()
+      expect(secureChannelMessages.unpair).not.toHaveBeenCalled()
       expect(mockOnPairSuccess).toHaveBeenCalled()
+    })
+
+    it('should roll back pairing when vault login fails', async () => {
+      const mockIdentity = {
+        ed25519PublicKey: 'pubKey',
+        x25519PublicKey: 'xKey'
+      }
+      secureChannelMessages.getIdentity.mockResolvedValue({
+        success: true,
+        identity: mockIdentity
+      })
+      secureChannelMessages.confirmPair.mockResolvedValue({ confirmed: true })
+      secureChannelMessages.unlockClientKeystore.mockResolvedValue({
+        success: true
+      })
+      secureChannelMessages.pinIdentity.mockResolvedValue({ success: true })
+      mockLogIn.mockRejectedValueOnce(new Error('Invalid master password'))
+
+      const { result } = renderHook(() => useDesktopPairing(props))
+
+      await act(async () => {
+        result.current.setPairingToken('token-long-enough')
+      })
+      await act(async () => {
+        await result.current.fetchIdentity()
+      })
+      await act(async () => {
+        await result.current.completePairing('wrong-password')
+      })
+
+      expect(secureChannelMessages.confirmPair).toHaveBeenCalled()
+      expect(secureChannelMessages.pinIdentity).toHaveBeenCalledWith(
+        mockIdentity
+      )
+      expect(mockLogIn).toHaveBeenCalledWith({ password: 'wrong-password' })
+      expect(secureChannelMessages.commitClientKeystore).not.toHaveBeenCalled()
+      expect(secureChannelMessages.unpair).toHaveBeenCalled()
+      expect(mockOnPairSuccess).not.toHaveBeenCalled()
+      expect(result.current.passwordError).toEqual(
+        expect.stringContaining('Invalid master password')
+      )
     })
 
     it('should clear pairing data on pairing failure', async () => {

--- a/src/shared/services/messageBridge.js
+++ b/src/shared/services/messageBridge.js
@@ -9,6 +9,7 @@ export const SECURE_MESSAGE_TYPES = Object.freeze({
   PIN_IDENTITY: 'PIN_IDENTITY',
   UNPAIR: 'SECURE_CHANNEL_UNPAIR',
   UNLOCK_CLIENT_KEYSTORE: 'SECURE_CHANNEL_UNLOCK_CLIENT_KEYSTORE',
+  COMMIT_CLIENT_KEYSTORE: 'SECURE_CHANNEL_COMMIT_CLIENT_KEYSTORE',
   GET_BLOCKING_STATE: 'SECURE_CHANNEL_GET_BLOCKING_STATE'
 })
 
@@ -240,6 +241,12 @@ export const secureChannelMessages = {
       {
         masterPassword
       }
+    )
+  },
+
+  async commitClientKeystore() {
+    return messageBridge.sendMessage(
+      SECURE_MESSAGE_TYPES.COMMIT_CLIENT_KEYSTORE
     )
   },
 


### PR DESCRIPTION
### Changes
- Defer the IndexedDB keystore write until after the master password unlocks the vault.
- Add `commitPendingClientKeystore` and a matching `SECURE_MESSAGE_TYPES.COMMIT_CLIENT_KEYSTORE` runtime message.
- Roll back pairing (`unpair()` + clear `pendingPairingStore`) when `logIn` / `initVaults` fails.
- Redirect the popup to onboarding 2s after a wrong-password rollback.
- `openOnboardingPage` always reloads the existing onboarding tab.
- Update the wrong-password message to mention pairing was reset.
- Remove the unused `nm.paired` flag from `chrome.storage.local`.
- Update tests for the new flow.


### Screenshots/Recordings

https://github.com/user-attachments/assets/82a739e6-23aa-4421-a414-c7c483d515c0