### PR TITLE
Add Revoke Access flow to paired devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6032,7 +6032,7 @@
     "node_modules/@tetherto/pearpass-lib-ui-kit": {
       "name": "pearpass-lib-ui-react-native-components",
       "version": "0.0.40",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#bba64ea96fad376a0f0b87d2729fe2742733d7d7",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#0301a142ff80a4c05b9efc245a9dc75a2bcdd8f2",
       "license": "Apache-2.0",
       "dependencies": {
         "react-strict-dom": "^0.0.55"
@@ -6071,7 +6071,7 @@
     "node_modules/@tetherto/pearpass-lib-vault": {
       "name": "pearpass-lib-vault",
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault.git#ecfff62dcef70c1acaf6d09a29bacf4001b8acb9",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault.git#7e58479a45f8f802d2e8cb8145d526e74495c3af",
       "license": "Apache-2.0",
       "dependencies": {
         "@reduxjs/toolkit": "2.5.0",

--- a/src/shared/commandDefinitions.js
+++ b/src/shared/commandDefinitions.js
@@ -35,6 +35,7 @@ export const COMMAND_DEFINITIONS = {
   activeVaultList: { params: ['filterKey'] },
   activeVaultAdd: { params: ['key', 'data'] },
   activeVaultRemove: { params: ['key'] },
+  activeVaultRemoveWriter: { params: ['writerKey'] },
   activeVaultClose: { params: [] },
   activeVaultCreateInvite: { params: [] },
   activeVaultDeleteInvite: { params: [] },

--- a/src/shared/containers/PairedDevicesModalContent/index.tsx
+++ b/src/shared/containers/PairedDevicesModalContent/index.tsx
@@ -24,7 +24,7 @@ import { getMyDeviceId, useVault } from '@tetherto/pearpass-lib-vault'
 
 import { useModal } from '../../context/ModalContext'
 import { logger } from '../../utils/logger'
-import { RevokeAccessModalContentV2 } from '../RevokeAccessModalContentV2'
+import { RevokeAccessModalContent } from '../RevokeAccessModalContent'
 
 const DEVICE_ACTIONS_MENU_WIDTH = 220
 
@@ -76,7 +76,7 @@ export const PairedDevicesModalContent = () => {
   const { theme } = useTheme()
 
   const { data: vaultData } = useVault()
-  const vaultId = (vaultData as { id?: string } | undefined)?.id ?? ''
+  const vaultId = (vaultData as { id?: string } | undefined)?.id ?? null
 
   const devices = useMemo<Device[]>(
     () =>
@@ -102,12 +102,12 @@ export const PairedDevicesModalContent = () => {
     return () => {
       cancelled = true
     }
-  }, [devices])
+  }, [])
 
   const openRevokeModal = (device: Device, displayName: string) => {
     if (!device.id || !vaultId) return
     setModal(
-      <RevokeAccessModalContentV2
+      <RevokeAccessModalContent
         vaultId={vaultId}
         targetDeviceId={device.id}
         deviceName={displayName}
@@ -147,6 +147,7 @@ export const PairedDevicesModalContent = () => {
               ? formatDate(device.createdAt, 'dd-mmm-yyyy', ' ')
               : null
             const isCurrentDevice = !!myDeviceId && device.id === myDeviceId
+            const canRevoke = !!vaultId && !!device.id && !isCurrentDevice
 
             return (
               <ListItem
@@ -166,7 +167,7 @@ export const PairedDevicesModalContent = () => {
                 }
                 testID={`paired-devices-item-${device.id ?? index}`}
                 rightElement={
-                  isCurrentDevice || !device.id ? undefined : (
+                  canRevoke ? (
                     <ContextMenu
                       menuWidth={DEVICE_ACTIONS_MENU_WIDTH}
                       testID={`paired-devices-row-menu-${device.id}`}
@@ -190,7 +191,7 @@ export const PairedDevicesModalContent = () => {
                         variant="destructive"
                         icon={
                           <DoNotDisturb
-                            color={theme.colors.colorSurfaceDestructiveElevated}
+                            color={theme.colors.colorTextDestructive}
                           />
                         }
                         label={t`Revoke Access`}
@@ -198,7 +199,7 @@ export const PairedDevicesModalContent = () => {
                         onClick={() => openRevokeModal(device, deviceName)}
                       />
                     </ContextMenu>
-                  )
+                  ) : undefined
                 }
               />
             )

--- a/src/shared/containers/PairedDevicesModalContent/index.tsx
+++ b/src/shared/containers/PairedDevicesModalContent/index.tsx
@@ -1,30 +1,40 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { t } from '@lingui/core/macro'
 import { formatDate } from '@tetherto/pear-apps-utils-date'
 import {
   Button,
+  ContextMenu,
   Dialog,
   ListItem,
+  NavbarListItem,
   Text,
   useTheme
 } from '@tetherto/pearpass-lib-ui-kit'
 import {
   Devices,
+  DoNotDisturb,
   LaptopMac,
   LaptopWindows,
+  MoreVert,
   PhoneIphone,
   Tablet
 } from '@tetherto/pearpass-lib-ui-kit/icons'
-import { useVault } from '@tetherto/pearpass-lib-vault'
+import { getMyDeviceId, useVault } from '@tetherto/pearpass-lib-vault'
 
 import { useModal } from '../../context/ModalContext'
+import { logger } from '../../utils/logger'
+import { RevokeAccessModalContentV2 } from '../RevokeAccessModalContentV2'
+
+const DEVICE_ACTIONS_MENU_WIDTH = 220
 
 type IconComponent = React.ComponentType<{
   width?: number
   height?: number
   color?: string
 }>
+
+type Device = { id?: string; name?: string; createdAt?: string }
 
 const getDeviceDisplayName = (deviceName: string | undefined): string => {
   if (!deviceName) return t`Unknown Device`
@@ -59,15 +69,51 @@ const getDeviceIcon = (deviceName?: string): IconComponent => {
 }
 
 export const PairedDevicesModalContent = () => {
-  const { closeModal } = useModal() as { closeModal: () => void }
+  const { closeModal, setModal } = useModal() as {
+    setModal: (content: React.ReactNode) => void
+    closeModal: () => void
+  }
   const { theme } = useTheme()
 
   const { data: vaultData } = useVault()
+  const vaultId = (vaultData as { id?: string } | undefined)?.id ?? ''
 
-  const devices = useMemo(
-    () => (Array.isArray(vaultData?.devices) ? vaultData.devices : []),
+  const devices = useMemo<Device[]>(
+    () =>
+      Array.isArray(vaultData?.devices) ? (vaultData.devices as Device[]) : [],
     [vaultData]
   )
+
+  const [myDeviceId, setMyDeviceId] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getMyDeviceId()
+      .then((id: string | null) => {
+        if (!cancelled) setMyDeviceId(id ?? null)
+      })
+      .catch((error: unknown) => {
+        logger.error(
+          'PairedDevicesModalContent',
+          'getMyDeviceId failed:',
+          error
+        )
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [devices])
+
+  const openRevokeModal = (device: Device, displayName: string) => {
+    if (!device.id || !vaultId) return
+    setModal(
+      <RevokeAccessModalContentV2
+        vaultId={vaultId}
+        targetDeviceId={device.id}
+        deviceName={displayName}
+      />
+    )
+  }
 
   return (
     <Dialog
@@ -94,38 +140,69 @@ export const PairedDevicesModalContent = () => {
         </div>
       ) : (
         <div className="flex flex-col">
-          {devices.map(
-            (
-              device: { id?: string; name?: string; createdAt?: string },
-              index: number
-            ) => {
-              const deviceName = getDeviceDisplayName(device.name)
-              const DeviceIcon = getDeviceIcon(device.name)
-              const createdAt = device.createdAt
-                ? formatDate(device.createdAt, 'dd-mmm-yyyy', ' ')
-                : null
+          {devices.map((device, index) => {
+            const deviceName = getDeviceDisplayName(device.name)
+            const DeviceIcon = getDeviceIcon(device.name)
+            const createdAt = device.createdAt
+              ? formatDate(device.createdAt, 'dd-mmm-yyyy', ' ')
+              : null
+            const isCurrentDevice = !!myDeviceId && device.id === myDeviceId
 
-              return (
-                <ListItem
-                  key={device.id ?? `${deviceName}-${index}`}
-                  icon={
-                    <div className="bg-surface-hover flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-[8px]">
-                      <DeviceIcon
-                        width={16}
-                        height={16}
-                        color={theme.colors.colorAccentActive}
+            return (
+              <ListItem
+                key={device.id ?? `${deviceName}-${index}`}
+                icon={
+                  <div className="bg-surface-hover flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-[8px]">
+                    <DeviceIcon
+                      width={16}
+                      height={16}
+                      color={theme.colors.colorAccentActive}
+                    />
+                  </div>
+                }
+                title={deviceName}
+                subtitle={
+                  createdAt ? `${t`Paired on`} ${createdAt}` : undefined
+                }
+                testID={`paired-devices-item-${device.id ?? index}`}
+                rightElement={
+                  isCurrentDevice || !device.id ? undefined : (
+                    <ContextMenu
+                      menuWidth={DEVICE_ACTIONS_MENU_WIDTH}
+                      testID={`paired-devices-row-menu-${device.id}`}
+                      trigger={
+                        <Button
+                          variant="tertiary"
+                          size="small"
+                          aria-label={t`Device actions`}
+                          iconBefore={
+                            <MoreVert
+                              width={16}
+                              height={16}
+                              color={theme.colors.colorTextPrimary}
+                            />
+                          }
+                        />
+                      }
+                    >
+                      <NavbarListItem
+                        size="small"
+                        variant="destructive"
+                        icon={
+                          <DoNotDisturb
+                            color={theme.colors.colorSurfaceDestructiveElevated}
+                          />
+                        }
+                        label={t`Revoke Access`}
+                        testID={`paired-devices-row-revoke-${device.id}`}
+                        onClick={() => openRevokeModal(device, deviceName)}
                       />
-                    </div>
-                  }
-                  title={deviceName}
-                  subtitle={
-                    createdAt ? `${t`Paired on`} ${createdAt}` : undefined
-                  }
-                  testID={`paired-devices-item-${device.id ?? index}`}
-                />
-              )
-            }
-          )}
+                    </ContextMenu>
+                  )
+                }
+              />
+            )
+          })}
         </div>
       )}
     </Dialog>

--- a/src/shared/containers/RevokeAccessModalContent/RevokeAccessModalContent.test.tsx
+++ b/src/shared/containers/RevokeAccessModalContent/RevokeAccessModalContent.test.tsx
@@ -1,0 +1,134 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { kickDevice, useVault } from '@tetherto/pearpass-lib-vault'
+
+import { RevokeAccessModalContent } from './index'
+import { useModal } from '../../context/ModalContext'
+import { useToast } from '../../context/ToastContext'
+
+jest.mock('@tetherto/pearpass-lib-vault', () => ({
+  kickDevice: jest.fn(),
+  useVault: jest.fn()
+}))
+
+jest.mock('../../context/ModalContext', () => ({
+  useModal: jest.fn()
+}))
+
+jest.mock('../../context/ToastContext', () => ({
+  useToast: jest.fn()
+}))
+
+jest.mock('../../utils/logger', () => ({
+  logger: { error: jest.fn() }
+}))
+
+jest.mock('@tetherto/pearpass-lib-ui-kit', () => {
+  const liftTestID = ({ testID, ...rest }: any) =>
+    testID ? { ...rest, 'data-testid': testID } : rest
+  return {
+    Button: ({ children, onClick, disabled, isLoading, ...rest }: any) => (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled || isLoading}
+        {...liftTestID(rest)}
+      >
+        {children}
+      </button>
+    ),
+    Dialog: ({ children, footer }: any) => (
+      <div>
+        {children}
+        {footer}
+      </div>
+    ),
+    Text: ({ children }: any) => <span>{children}</span>
+  }
+})
+
+const mockedKickDevice = jest.mocked(kickDevice)
+const mockedUseVault = jest.mocked(useVault)
+const mockedUseModal = jest.mocked(useModal)
+const mockedUseToast = jest.mocked(useToast)
+
+describe('RevokeAccessModalContent', () => {
+  const refetchVault = jest.fn()
+  const closeModal = jest.fn()
+  const setToast = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    refetchVault.mockResolvedValue(undefined)
+    mockedUseVault.mockReturnValue({
+      refetch: refetchVault
+    } as unknown as ReturnType<typeof useVault>)
+    mockedUseModal.mockReturnValue({
+      closeModal
+    } as unknown as ReturnType<typeof useModal>)
+    mockedUseToast.mockReturnValue({ setToast } as unknown as ReturnType<
+      typeof useToast
+    >)
+  })
+
+  const renderModal = () =>
+    render(
+      <RevokeAccessModalContent
+        vaultId="v1"
+        targetDeviceId="d2"
+        deviceName="iPhone"
+      />
+    )
+
+  const submit = async () => {
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('revoke-access-submit'))
+    })
+  }
+
+  it('on success: closes the modal and shows the success toast', async () => {
+    mockedKickDevice.mockResolvedValue({ results: [], failures: [] } as any)
+
+    renderModal()
+    await submit()
+
+    expect(mockedKickDevice).toHaveBeenCalledWith({
+      vaultId: 'v1',
+      targetDeviceId: 'd2'
+    })
+    expect(refetchVault).toHaveBeenCalledWith('v1')
+    expect(closeModal).toHaveBeenCalled()
+    expect(setToast).toHaveBeenCalledWith({
+      message: expect.stringMatching(/no longer has access/)
+    })
+  })
+
+  it('on partial failure: closes the modal and shows the unreachable-device toast', async () => {
+    mockedKickDevice.mockResolvedValue({
+      results: [],
+      failures: [{ targetDeviceId: 'd2', error: new Error('offline') }]
+    } as any)
+
+    renderModal()
+    await submit()
+
+    expect(closeModal).toHaveBeenCalled()
+    expect(setToast).toHaveBeenCalledWith({
+      message: expect.stringMatching(/lose access next time it comes online/)
+    })
+  })
+
+  it('on kickDevice throw: shows the generic error toast, keeps the modal open with submit re-enabled', async () => {
+    mockedKickDevice.mockRejectedValue(new Error('boom'))
+
+    renderModal()
+    await submit()
+
+    expect(closeModal).not.toHaveBeenCalled()
+    expect(setToast).toHaveBeenCalledWith({
+      message: expect.stringMatching(/Couldn't revoke access/)
+    })
+    expect(
+      (screen.getByTestId('revoke-access-submit') as HTMLButtonElement).disabled
+    ).toBe(false)
+  })
+})

--- a/src/shared/containers/RevokeAccessModalContent/index.tsx
+++ b/src/shared/containers/RevokeAccessModalContent/index.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+
+import { t } from '@lingui/core/macro'
+import { Button, Dialog, Text } from '@tetherto/pearpass-lib-ui-kit'
+import { kickDevice, useVault } from '@tetherto/pearpass-lib-vault'
+
+import { useModal } from '../../context/ModalContext'
+import { useToast } from '../../context/ToastContext'
+import { logger } from '../../utils/logger'
+
+export type RevokeAccessModalContentProps = {
+  vaultId: string
+  targetDeviceId: string
+  deviceName: string
+}
+
+export const RevokeAccessModalContent = ({
+  vaultId,
+  targetDeviceId,
+  deviceName
+}: RevokeAccessModalContentProps) => {
+  const { closeModal } = useModal() as { closeModal: () => void }
+  const { setToast } = useToast() as {
+    setToast: (toast: { message: string }) => void
+  }
+  const { refetch: refetchVault } = useVault()
+
+  const [isLoading, setIsLoading] = useState(false)
+
+  const onRevoke = async () => {
+    if (isLoading) return
+    setIsLoading(true)
+    try {
+      const { failures } = await kickDevice({ vaultId, targetDeviceId })
+
+      try {
+        await refetchVault(vaultId)
+      } catch (error) {
+        logger.error('RevokeAccessModalContent', 'refetch failed:', error)
+      }
+
+      closeModal()
+      setToast({
+        message: failures?.length
+          ? t`Couldn't reach the device. It will lose access next time it comes online.`
+          : t`"${deviceName}" no longer has access to this vault`
+      })
+    } catch (error) {
+      logger.error('RevokeAccessModalContent', 'kickDevice failed:', error)
+      setToast({
+        message: t`Couldn't revoke access. Please try again.`
+      })
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Dialog
+      title={t`Revoke access for ${deviceName}?`}
+      onClose={closeModal}
+      testID="revoke-access-dialog"
+      closeButtonTestID="revoke-access-close"
+      footer={
+        <div className="flex w-full justify-end gap-[var(--spacing8)]">
+          <Button
+            variant="secondary"
+            size="small"
+            type="button"
+            onClick={closeModal}
+            disabled={isLoading}
+            data-testid="revoke-access-cancel"
+          >
+            {t`Cancel`}
+          </Button>
+          <Button
+            variant="destructive"
+            size="small"
+            type="button"
+            isLoading={isLoading}
+            onClick={onRevoke}
+            data-testid="revoke-access-submit"
+          >
+            {t`Revoke Access`}
+          </Button>
+        </div>
+      }
+    >
+      <div
+        className="flex w-full flex-col gap-[var(--spacing12)]"
+        data-testid="revoke-access-body"
+      >
+        <div className="flex flex-col">
+          <Text as="p" variant="caption">
+            {t`This will disconnect the device from future syncing.`}
+          </Text>
+          <Text as="p" variant="caption">
+            {t`Before you proceed, please note:`}
+          </Text>
+        </div>
+        <ul className="m-0 flex list-outside list-disc flex-col gap-[var(--spacing12)] pl-[var(--spacing20)]">
+          <li className="m-0">
+            <Text as="span" variant="caption">
+              {t`For Your Security: We recommend moving your items to a new vault and updating your passwords. This is especially important if the device was lost or stolen, as it ensures your data remains protected even if a local copy exists on the revoked device.`}
+            </Text>
+          </li>
+          <li className="m-0">
+            <Text as="span" variant="caption">
+              {t`Offline Data: Revoking access prevents future syncing, but it cannot remotely delete data that was already exported.`}
+            </Text>
+          </li>
+        </ul>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/tetherto-modules.d.ts
+++ b/src/tetherto-modules.d.ts
@@ -312,13 +312,15 @@ declare module '@tetherto/pearpass-lib-vault' {
     failures: Array<{ targetDeviceId: string; error: Error }>
   }>
 
-  export function useFindOtpDuplicates(params?: {
-    secret?: string | null
-    excludeRecordId?: string
-  }): {
-    data: Array<{ id: string; title: string }>
-    isLoading: boolean
-  }
+  export function kickDevice(params: {
+    vaultId: string
+    targetDeviceId: string
+  }): Promise<{
+    results: Array<{ targetDeviceId: string; channel: 'outbox' }>
+    failures: Array<{ targetDeviceId: string; error: Error }>
+  }>
+
+  export function getMyDeviceId(): Promise<string | null>
 }
 
 declare module '@tetherto/pearpass-lib-vault/src/instances' {

--- a/src/tetherto-modules.d.ts
+++ b/src/tetherto-modules.d.ts
@@ -312,6 +312,14 @@ declare module '@tetherto/pearpass-lib-vault' {
     failures: Array<{ targetDeviceId: string; error: Error }>
   }>
 
+  export function useFindOtpDuplicates(params?: {
+    secret?: string | null
+    excludeRecordId?: string
+  }): {
+    data: Array<{ id: string; title: string }>
+    isLoading: boolean
+  }
+
   export function kickDevice(params: {
     vaultId: string
     targetDeviceId: string


### PR DESCRIPTION
### Changes:
- New `RevokeAccessModalContentV2` confirm dialog that calls `kickDevice` and surfaces a single success-or-partial-failure toast.
- `PairedDevicesModalContent`: per-row context menu with a destructive "Revoke Access" action; hidden on the self row (detected via `getMyDeviceId`).
- Add `kickDevice` and `getMyDeviceId` declarations to the local `tetherto-modules.d.ts` override.
- Bump `pearpass-lib-vault` to the merged `kickDevice` sha and `pearpass-lib-ui-kit` for the `DoNotDisturb` icon.

### Recordings

https://github.com/user-attachments/assets/c74f869c-2287-4ea9-9346-a663556799a4

